### PR TITLE
Sync with hive-mind: Opus 4.7, gpt-5.5, nemotron-3-super-free + bidirectional I/O analysis

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-26T20:35:07.899Z for PR creation at branch issue-22-5e0a7d1a9d81 for issue https://github.com/link-assistant/agent-commander/issues/22

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-26T20:35:07.899Z for PR creation at branch issue-22-5e0a7d1a9d81 for issue https://github.com/link-assistant/agent-commander/issues/22

--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ bun add agent-commander
 | Tool | Description | JSON Output | JSON Input | Read-only Mode | Model Aliases |
 |------|-------------|-------------|------------|----------------|---------------|
 | `claude` | Anthropic Claude Code CLI | ✅ (stream-json) | ✅ (stream-json) | ✅ `--permission-mode plan` | `sonnet`, `opus`, `haiku` |
-| `codex` | OpenAI Codex CLI | ✅ | ❌ | ✅ `--sandbox read-only` | `gpt5`, `o3`, `gpt4o` |
+| `codex` | OpenAI Codex CLI | ✅ | ❌ | ✅ `--sandbox read-only` | `gpt-5.5` (default), `gpt-5.4`, `gpt5`, `o3`, `gpt4o` |
 | `opencode` | OpenCode CLI | ✅ | ❌ | ✅ `OPENCODE_PERMISSION` deny rules | `grok`, `gemini`, `sonnet` |
 | `qwen` | Qwen Code CLI | ✅ (stream-json) | ✅ (stream-json) | ✅ `--approval-mode plan` | `qwen3-coder`, `coder`, `gpt-4o` |
 | `gemini` | Gemini CLI | ✅ (stream-json) | ❌ | ✅ `--approval-mode plan` | `flash`, `pro`, `lite` |
-| `agent` | @link-assistant/agent | ✅ | ✅ | ❌ not enforceable | `grok`, `sonnet`, `haiku` |
+| `agent` | @link-assistant/agent | ✅ | ✅ | ❌ not enforceable | `nemotron-3-super-free` (default), `grok`, `sonnet`, `haiku` |
 
 ### Claude-specific Features
 
@@ -460,11 +460,11 @@ console.log(isToolSupported({ toolName: 'claude' })); // true
 
 // Get tool configuration
 const claudeTool = getTool({ toolName: 'claude' });
-console.log(claudeTool.modelMap); // { sonnet: 'claude-sonnet-4-5-...', ... }
+console.log(claudeTool.modelMap); // { sonnet: 'claude-sonnet-4-6', opus: 'claude-opus-4-7', ... }
 
 // Map model alias to full ID
 const fullId = claudeTool.mapModelToId({ model: 'opus' });
-console.log(fullId); // 'claude-opus-4-5-20251101'
+console.log(fullId); // 'claude-opus-4-7'
 ```
 
 ## API Reference

--- a/docs/case-studies/issue-22/README.md
+++ b/docs/case-studies/issue-22/README.md
@@ -1,0 +1,147 @@
+# Case Study: Sync with hive-mind (Issue #22)
+
+## Problem Statement
+
+agent-commander was originally extracted from [hive-mind](https://github.com/link-assistant/hive-mind) on 2025-11-11 (commit `bd25d5a`). The model maps and best practices were re-synced on 2026-04-05 in PR #18 (issue #17). Issue #22 asks us to:
+
+1. Determine the last sync date.
+2. Compare hive-mind and agent-commander file trees so we don't miss features or bug fixes.
+3. Sync any new model-map changes and tool best practices.
+4. Examine the experimental bidirectional JSON I/O work for Claude and report what's missing in the other CLIs (and in `link-assistant/agent`, where issues should be filed).
+5. Compile this case study under `docs/case-studies/issue-22/` with requirements, analysis, and a solution plan.
+
+## Investigation Timeline
+
+| Date | Event |
+|------|-------|
+| 2025-11-11 | Initial extraction from hive-mind (`bd25d5a`). |
+| 2026-04-05 | Last full sync (PR #18 / issue #17). Brought Claude to 4.6 and added `minimax-m2.5-free` family. |
+| 2026-04-08 — 2026-04-26 | Hive-mind continued evolving — Opus 4.7, gpt-5.5 family, `nemotron-3-super-free` default for agent. |
+| 2026-04-26 | This sync (issue #22). |
+
+So the gap to close in this iteration is ~3 weeks of hive-mind work, hive-mind versions roughly v1.49 → **v1.57.2** (latest release on 2026-04-26).
+
+## Requirements (extracted from the issue)
+
+1. Determine when the last sync happened.
+2. Compare both repos' file trees so nothing is missed.
+3. Sync model maps and bug fixes that landed in hive-mind after that date.
+4. Investigate the bidirectional JSON I/O work that was started for Claude and replicate it for the other CLIs where supported.
+5. File issues against `link-assistant/agent` for any missing bidirectional I/O capabilities (Codex too, "if they allow bidirectional input/output in JSON").
+6. Compile data into `docs/case-studies/issue-22/`, list every requirement, propose solutions, and identify reusable components.
+7. Search online for additional facts/data when relevant.
+
+## Diff Summary — what's new in hive-mind since 2026-04-05
+
+Source: `gh api repos/link-assistant/hive-mind/contents/src/models/index.mjs` (raw fetch on 2026-04-26) and `gh pr list --repo link-assistant/hive-mind --search 'merged:>2026-04-05'`.
+
+### Model maps
+
+| Tool | Change | Hive-mind PR |
+|------|--------|--------------|
+| Claude | `opus` now resolves to `claude-opus-4-7` (was `claude-opus-4-6`). New aliases `opus-4-7`, `claude-opus-4-7`. Added to `MODELS_SUPPORTING_1M_CONTEXT`. New `defaultFallbackModels.claude` map with `opus-4-7 -> opus-4-6`. | #1620, #1621 |
+| Codex | New default `gpt-5.5`. New aliases: `gpt-5.5`, `gpt-5.5-mini`, `gpt-5.5-nano`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.2`, `gpt-5.2-codex`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.1-codex-max`. New `CODEX_DEFAULT_FALLBACK_CHAIN` and runtime model resolution via `codex debug models`. | #1657 |
+| Agent | Default changed to `nemotron-3-super-free` (NVIDIA hybrid Mamba-Transformer). `qwen3.6-plus-free` is now deprecated (free promotion ended April 2026). | #1543, #1564 (mirrors agent PR #243) |
+| OpenCode | No changes. | — |
+| Qwen | Not present in hive-mind; agent-commander remains the source of truth. | — |
+| Gemini | Not present in hive-mind; agent-commander remains the source of truth. | — |
+
+### Tool features (mostly Codex-heavy)
+
+- PR #1602 (Apr 15): better Codex support; PR #1607 / #1604: Codex Playwright MCP setup docs.
+- PR #1636 (Apr 18): Fix Codex pricing estimates.
+- PR #1661 (Apr 24): Treat Codex error events as failed runs; PR #1697 (Apr 26): Fix Codex false failure on app-server stream lag (`getCodexErrorEventSummary` aggregates `itemErrors`, `turnFailures`, `streamErrors` and ignores non-fatal stream lag items).
+- PR #1617: Preserve PR issue links after Codex auto-restart.
+- PR #1674: Resume Codex stream disconnects.
+- Claude: PR #1628 disables useless tools and MCP connectors in autonomous runs (`useless-tools.lib.mjs`); PR #1643 disables noisy Claude Code features in solve/Docker. New `src/claude.command-builder.lib.mjs` (89 lines) extracts shared command-building.
+
+### Execution-layer (cross-tool)
+
+- PR #1624: Playwright MCP fallback guidance for all tools.
+- PR #1591: Sub-agent call tracking with per-call stats in budget display.
+- PR #1599: Make all long sleeps interruptible (CTRL+C responsive).
+- PR #1538: Retry on network issues with minimized terminal/log diff.
+- PR #1542: Filter verbose log messages falsely emitted as error events.
+- PR #1667: Retry capacity failures with fallback models (uses `defaultFallbackModels`).
+
+### Infra / not for sync
+
+Heavy Telegram-bot work (#1685, #1689, #1687, #1693, #1695), screen session monitoring, GitHub merge logic, Sentry integration. These belong to hive-mind's execution layer and stay there.
+
+## Bidirectional JSON I/O Status
+
+The issue specifically calls out the experimental Claude bidirectional JSON I/O. Here is what I found.
+
+### Claude
+
+- Hive-mind has `src/bidirectional-interactive.lib.mjs` (~710 lines) that drives a true bidirectional Claude session: writes NDJSON frames into stdin (`--input-format stream-json`), reads NDJSON frames from stdout (`--output-format stream-json --verbose`), and supports `--replay-user-messages` for live UI updates. Issue #817 / PR #843.
+- agent-commander already has the building blocks: `claude.mjs` builds `--input-format stream-json` and `--output-format stream-json` flags; `streaming/input-stream.mjs` and `streaming/output-stream.mjs` produce/parse NDJSON. The `controller.start({ onMessage, onOutput })` API is in place. What is **not** in agent-commander is the live "attach a writer to stdin while reading from stdout" loop (e.g. `attachStreamingInput`).
+- That live loop sits squarely in the execution layer. agent-commander deliberately stays as a thin command builder + parser (see issue #17 case study). So the right move is to **not** port the 710-line live driver, but to (a) confirm the flag generation is correct and (b) document a recipe.
+
+### Other CLIs
+
+| CLI | Stream-JSON output | Stream-JSON input | Notes |
+|-----|--------------------|-------------------|-------|
+| Claude | yes (`--output-format stream-json --verbose`) | yes (`--input-format stream-json`) | Only CLI with true bidirectional today. |
+| Codex | yes (`--json` -> NDJSON) | no | Hive-mind pipes plain text via `cat promptFile \| codex exec`. OpenAI Codex CLI does not currently expose `--input-format stream-json`. |
+| OpenCode | yes (`run --format json`, NDJSON) | no | No stdin JSON frame protocol documented. |
+| Agent (`@link-assistant/agent`) | yes (NDJSON, OpenCode-compatible) | partial — accepts a single prompt via stdin but no NDJSON-frame-driven bidirectional loop. agent-commander declares `supportsJsonInput: true` because of the stdin support. | Needs an issue to add real `--input-format stream-json` parity. |
+| Qwen | yes (`--output-format stream-json`) | declared `true` based on docs but no live bidirectional driver in hive-mind. | Worth verifying upstream. |
+| Gemini | yes (`--output-format stream-json`) | no (`-p` flag for prompt) | Worth filing upstream FR. |
+
+So the only CLI in the supported set with a real, working bidirectional NDJSON I/O contract today is Claude. The other CLIs need upstream support before agent-commander can offer the same.
+
+## Root Cause Analysis
+
+There is no defect — this is a planned periodic sync. The "root cause" of any drift is simply that hive-mind ships ~10× faster than agent-commander, and we periodically need to pull model-map changes and any execution-layer changes that genuinely belong in the thin layer.
+
+The non-sync part of the issue (bidirectional JSON I/O for non-Claude tools) is upstream-blocked: the CLIs don't expose the input format, so we cannot replicate the bidirectional pattern in agent-commander until they do.
+
+## Solution Plan
+
+### 1. Sync model maps (this PR)
+
+- **Claude (JS + Rust)**: change `opus` → `claude-opus-4-7`; add `opus-4-7` and `claude-opus-4-7` aliases; keep `opus-4-6` for backward compatibility.
+- **Codex (JS + Rust)**: add the `gpt-5.5/5.4/5.3/5.2/5.1` family; change `defaultModel` from `gpt-5` to `gpt-5.5`; keep existing aliases.
+- **Agent (JS + Rust)**: add `nemotron-3-super-free` (mapped to `opencode/nemotron-3-super-free`); change `defaultModel` from `minimax-m2.5-free` to `nemotron-3-super-free`; mark `qwen3.6-plus-free` deprecated (kept for backward compatibility).
+- **OpenCode**: no model changes.
+- **Tests**: update JS and Rust tests that assert the previous model IDs and defaults.
+- **README**: update model-alias columns to reflect the new defaults.
+
+### 2. File issues for missing bidirectional I/O
+
+- Open an issue against `link-assistant/agent` requesting `--input-format stream-json` parity with Claude (referencing hive-mind PR #843 and `bidirectional-interactive.lib.mjs`).
+- Note in this case study that Codex bidirectional support requires upstream OpenAI work — the hive-mind file already says "Currently only supported for Claude due to `--input-format stream-json` support".
+
+### 3. Future-sync candidates (not in this PR)
+
+These are valuable but belong to subsequent issues, not this one:
+
+- Pull `unicode-sanitization.lib.mjs` (~67 lines) — generic, would benefit `parseOutput` everywhere.
+- Pull `parseModelWith1mSuffix` and `MODELS_SUPPORTING_1M_CONTEXT` to support Claude's `[1m]` 1M-token context window.
+- Pull `getCodexErrorEventSummary` (~100 lines) into `codex.mjs` for richer error parsing.
+- Centralize model maps into `js/src/tools/models.mjs` (mirror hive-mind's `src/models/index.mjs` pattern) so future syncs are diff-friendly.
+- Pull `defaultFallbackModels` (Claude `opus-4-7 -> opus-4-6`, Codex chain) so callers can opt into auto-retry on overload.
+
+These are listed in the "Recommendations for Future Syncs" section of issue-17's case study; this PR does not block on them.
+
+## Verification Strategy
+
+- `npm test` in `js/` passes after model-map and test updates.
+- `cargo test` in `rust/` passes after model-map and test updates.
+- A manual `start-agent --tool codex --dry-run --model gpt-5.5 --prompt "x"` shows the new model in the rendered command.
+- The README "Supported Tools" table still renders truthfully (no claims of bidirectional NDJSON for non-Claude tools).
+
+## Sources
+
+- Issue: https://github.com/link-assistant/agent-commander/issues/22
+- Previous sync issue: https://github.com/link-assistant/agent-commander/issues/17
+- hive-mind models file: https://github.com/link-assistant/hive-mind/blob/main/src/models/index.mjs
+- hive-mind bidirectional driver: https://github.com/link-assistant/hive-mind/blob/main/src/bidirectional-interactive.lib.mjs
+- hive-mind issue tracking the pattern: https://github.com/link-assistant/hive-mind/issues/817
+- hive-mind PR enabling Claude bidirectional: https://github.com/link-assistant/hive-mind/pull/843
+- Opus 4.7 hive-mind PR: https://github.com/link-assistant/hive-mind/pull/1621
+- gpt-5.5 / Codex defaults hive-mind PR: https://github.com/link-assistant/hive-mind/pull/1657
+- `nemotron-3-super-free` agent PR: https://github.com/link-assistant/agent/pull/243
+- link-assistant/agent README: https://github.com/link-assistant/agent#readme
+- Claude Code permissions / `--input-format stream-json`: https://code.claude.com/docs/en/headless-mode

--- a/docs/case-studies/issue-22/README.md
+++ b/docs/case-studies/issue-22/README.md
@@ -110,8 +110,8 @@ The non-sync part of the issue (bidirectional JSON I/O for non-Claude tools) is 
 
 ### 2. File issues for missing bidirectional I/O
 
-- Open an issue against `link-assistant/agent` requesting `--input-format stream-json` parity with Claude (referencing hive-mind PR #843 and `bidirectional-interactive.lib.mjs`).
-- Note in this case study that Codex bidirectional support requires upstream OpenAI work — the hive-mind file already says "Currently only supported for Claude due to `--input-format stream-json` support".
+- Filed [link-assistant/agent#268](https://github.com/link-assistant/agent/issues/268): "Add bidirectional NDJSON I/O via `--input-format stream-json` (parity with Claude Code)". This includes the proposed input-frame contract, references to hive-mind's bidirectional driver, and a test plan.
+- Codex bidirectional support requires upstream OpenAI work — the hive-mind driver itself says "Currently only supported for Claude due to `--input-format stream-json` support". No agent-commander-side work needed until OpenAI exposes the input format. (We could file a feature request against openai/codex if/when that becomes a priority for hive-mind.)
 
 ### 3. Future-sync candidates (not in this PR)
 

--- a/js/.changeset/sync-hive-mind-2026-04-26.md
+++ b/js/.changeset/sync-hive-mind-2026-04-26.md
@@ -1,0 +1,9 @@
+---
+'agent-commander': minor
+---
+
+Sync model maps from hive-mind v1.57.2 (issue #22):
+
+- Claude: `opus` now resolves to `claude-opus-4-7` (was `claude-opus-4-6`); add `opus-4-7` and `claude-opus-4-7` aliases. `opus-4-6` retained for backward compatibility.
+- Codex: add `gpt-5.5` family (and `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2`, `gpt-5.2-codex`, `gpt-5.1-codex-max`); default model changed from `gpt-5` to `gpt-5.5`.
+- Agent: add `nemotron-3-super-free` (NVIDIA hybrid Mamba-Transformer); default model changed from `minimax-m2.5-free` to `nemotron-3-super-free`; mark `qwen3.6-plus-free` as deprecated (kept for backward compatibility).

--- a/js/src/tools/agent.mjs
+++ b/js/src/tools/agent.mjs
@@ -16,6 +16,8 @@ export const modelMap = {
   'big-pickle': 'opencode/big-pickle',
   'gpt-5-nano': 'opencode/gpt-5-nano',
   'minimax-m2.5-free': 'opencode/minimax-m2.5-free',
+  // Default: NVIDIA hybrid Mamba-Transformer (hive-mind issue #1563, agent PR #243)
+  'nemotron-3-super-free': 'opencode/nemotron-3-super-free',
   // Kilo Gateway free models
   'glm-5-free': 'kilo/glm-5-free',
   'glm-4.5-air-free': 'kilo/glm-4.5-air-free',
@@ -30,6 +32,7 @@ export const modelMap = {
   'kilo/giga-potato-free': 'kilo/giga-potato-free',
   'kilo/trinity-large-preview': 'kilo/trinity-large-preview',
   // Deprecated free models (kept for backward compatibility)
+  'qwen3.6-plus-free': 'opencode/qwen3.6-plus-free', // Deprecated: free promotion ended April 2026
   'kimi-k2.5-free': 'opencode/kimi-k2.5-free',
   'glm-4.7-free': 'opencode/glm-4.7-free',
   'minimax-m2.1-free': 'opencode/minimax-m2.1-free',
@@ -270,7 +273,7 @@ export const agentTool = {
   supportsSystemPrompt: false, // System prompt is combined with user prompt
   supportsResume: false, // Agent doesn't have explicit resume like Claude
   supportsReadOnly: false, // No native enforceable read-only mode
-  defaultModel: 'minimax-m2.5-free',
+  defaultModel: 'nemotron-3-super-free', // hive-mind issue #1563, agent PR #243
   modelMap,
   mapModelToId,
   buildArgs,

--- a/js/src/tools/claude.mjs
+++ b/js/src/tools/claude.mjs
@@ -9,19 +9,21 @@
  */
 export const modelMap = {
   sonnet: 'claude-sonnet-4-6',
-  opus: 'claude-opus-4-6',
+  opus: 'claude-opus-4-7', // Opus 4.7 (hive-mind issue #1620, PR #1621)
   haiku: 'claude-haiku-4-5-20251001',
   'haiku-3-5': 'claude-3-5-haiku-20241022',
   'haiku-3': 'claude-3-haiku-20240307',
   opusplan: 'opusplan', // Special mode: Opus for planning, Sonnet for execution
   // Shorter version aliases
   'sonnet-4-6': 'claude-sonnet-4-6',
+  'opus-4-7': 'claude-opus-4-7',
   'opus-4-6': 'claude-opus-4-6',
   'opus-4-5': 'claude-opus-4-5-20251101',
   'sonnet-4-5': 'claude-sonnet-4-5-20250929', // Backward compatibility
   'haiku-4-5': 'claude-haiku-4-5-20251001',
   // Full model ID aliases for backward compatibility
   'claude-sonnet-4-6': 'claude-sonnet-4-6',
+  'claude-opus-4-7': 'claude-opus-4-7',
   'claude-opus-4-6': 'claude-opus-4-6',
   'claude-opus-4-5': 'claude-opus-4-5-20251101',
   'claude-sonnet-4-5': 'claude-sonnet-4-5-20250929',

--- a/js/src/tools/codex.mjs
+++ b/js/src/tools/codex.mjs
@@ -9,11 +9,30 @@
  */
 export const modelMap = {
   gpt5: 'gpt-5',
+  'gpt-5': 'gpt-5',
   'gpt5-codex': 'gpt-5-codex',
+  // GPT-5.5 family (hive-mind PR #1657, default)
+  'gpt-5.5': 'gpt-5.5',
+  'gpt-5.5-mini': 'gpt-5.5-mini',
+  'gpt-5.5-nano': 'gpt-5.5-nano',
+  // GPT-5.4 family
+  'gpt-5.4': 'gpt-5.4',
+  'gpt-5.4-mini': 'gpt-5.4-mini',
+  'gpt-5.4-nano': 'gpt-5.4-nano',
+  // GPT-5.3 family (codex variants)
+  'gpt-5.3-codex': 'gpt-5.3-codex',
+  'gpt-5.3-codex-spark': 'gpt-5.3-codex-spark',
+  // GPT-5.2 family
+  'gpt-5.2': 'gpt-5.2',
+  'gpt-5.2-codex': 'gpt-5.2-codex',
+  // GPT-5.1 family
+  'gpt-5.1-codex-max': 'gpt-5.1-codex-max',
   o3: 'o3',
   'o3-mini': 'o3-mini',
   gpt4: 'gpt-4',
+  'gpt-4': 'gpt-4',
   gpt4o: 'gpt-4o',
+  'gpt-4o': 'gpt-4o',
   claude: 'claude-3-5-sonnet',
   sonnet: 'claude-3-5-sonnet',
   opus: 'claude-3-opus',
@@ -207,7 +226,7 @@ export const codexTool = {
   supportsSystemPrompt: false, // System prompt is combined with user prompt
   supportsResume: true,
   supportsReadOnly: true, // Supports --sandbox read-only
-  defaultModel: 'gpt-5',
+  defaultModel: 'gpt-5.5', // hive-mind PR #1657
   modelMap,
   mapModelToId,
   buildArgs,

--- a/js/test/command-builder.test.mjs
+++ b/js/test/command-builder.test.mjs
@@ -95,7 +95,7 @@ test('buildAgentCommand - with model (claude)', () => {
 
   assert.ok(command.includes('--model'));
   // Opus model should be mapped to full ID
-  assert.ok(command.includes('claude-opus-4-6'));
+  assert.ok(command.includes('claude-opus-4-7'));
 });
 
 test('buildAgentCommand - with codex tool', () => {

--- a/js/test/tools.test.mjs
+++ b/js/test/tools.test.mjs
@@ -60,11 +60,27 @@ test('claudeTool - mapModelToId with alias', () => {
   );
   assert.strictEqual(
     claudeTool.mapModelToId({ model: 'opus' }),
-    'claude-opus-4-6'
+    'claude-opus-4-7'
   );
   assert.strictEqual(
     claudeTool.mapModelToId({ model: 'haiku' }),
     'claude-haiku-4-5-20251001'
+  );
+});
+
+test('claudeTool - mapModelToId with new opus 4.7 alias', () => {
+  assert.strictEqual(
+    claudeTool.mapModelToId({ model: 'opus-4-7' }),
+    'claude-opus-4-7'
+  );
+  assert.strictEqual(
+    claudeTool.mapModelToId({ model: 'claude-opus-4-7' }),
+    'claude-opus-4-7'
+  );
+  // Backward compatibility - opus-4-6 still maps explicitly
+  assert.strictEqual(
+    claudeTool.mapModelToId({ model: 'opus-4-6' }),
+    'claude-opus-4-6'
   );
 });
 
@@ -117,7 +133,7 @@ test('claudeTool - buildArgs uses stream-json output format', () => {
 test('claudeTool - buildArgs with fallback model', () => {
   const args = claudeTool.buildArgs({ model: 'opus', fallbackModel: 'sonnet' });
   assert.ok(args.includes('--model'));
-  assert.ok(args.includes('claude-opus-4-6'));
+  assert.ok(args.includes('claude-opus-4-7'));
   assert.ok(args.includes('--fallback-model'));
   assert.ok(args.includes('claude-sonnet-4-6'));
 });
@@ -215,6 +231,23 @@ test('codexTool - extractSessionId with thread_id', () => {
   assert.strictEqual(sessionId, 'thread-123');
 });
 
+test('codexTool - mapModelToId with gpt-5.5 family aliases', () => {
+  assert.strictEqual(codexTool.mapModelToId({ model: 'gpt-5.5' }), 'gpt-5.5');
+  assert.strictEqual(
+    codexTool.mapModelToId({ model: 'gpt-5.5-mini' }),
+    'gpt-5.5-mini'
+  );
+  assert.strictEqual(codexTool.mapModelToId({ model: 'gpt-5.4' }), 'gpt-5.4');
+  assert.strictEqual(
+    codexTool.mapModelToId({ model: 'gpt-5.3-codex' }),
+    'gpt-5.3-codex'
+  );
+});
+
+test('codexTool - default model is gpt-5.5', () => {
+  assert.strictEqual(codexTool.defaultModel, 'gpt-5.5');
+});
+
 // OpenCode tool tests
 test('opencodeTool - mapModelToId with alias', () => {
   assert.strictEqual(
@@ -272,6 +305,24 @@ test('agentTool - detectErrors returns false for normal output', () => {
   const output = '{"type":"step_finish","part":{}}';
   const result = agentTool.detectErrors({ output });
   assert.strictEqual(result.hasError, false);
+});
+
+test('agentTool - mapModelToId with nemotron-3-super-free (new default)', () => {
+  assert.strictEqual(
+    agentTool.mapModelToId({ model: 'nemotron-3-super-free' }),
+    'opencode/nemotron-3-super-free'
+  );
+});
+
+test('agentTool - default model is nemotron-3-super-free', () => {
+  assert.strictEqual(agentTool.defaultModel, 'nemotron-3-super-free');
+});
+
+test('agentTool - mapModelToId keeps deprecated qwen3.6-plus-free for backward compatibility', () => {
+  assert.strictEqual(
+    agentTool.mapModelToId({ model: 'qwen3.6-plus-free' }),
+    'opencode/qwen3.6-plus-free'
+  );
 });
 
 // Qwen tool tests

--- a/rust/changelog.d/20260426_193000_sync_hive_mind_2026_04_26.md
+++ b/rust/changelog.d/20260426_193000_sync_hive_mind_2026_04_26.md
@@ -1,0 +1,6 @@
+---
+bump: minor
+---
+
+### Changed
+- Synced model maps from hive-mind v1.57.2 (issue #22): Claude `opus` -> `claude-opus-4-7`; Codex default `gpt-5` -> `gpt-5.5` and added the `gpt-5.5/5.4/5.3/5.2/5.1` family; Agent default `minimax-m2.5-free` -> `nemotron-3-super-free` with `qwen3.6-plus-free` retained as deprecated.

--- a/rust/src/command_builder.rs
+++ b/rust/src/command_builder.rs
@@ -399,7 +399,7 @@ mod tests {
 
         let command = build_agent_command(&options);
         assert!(command.contains("--model"));
-        assert!(command.contains("claude-opus-4-6"));
+        assert!(command.contains("claude-opus-4-7"));
     }
 
     #[test]

--- a/rust/src/tools/agent.rs
+++ b/rust/src/tools/agent.rs
@@ -17,6 +17,8 @@ pub fn get_model_map() -> HashMap<&'static str, &'static str> {
     map.insert("big-pickle", "opencode/big-pickle");
     map.insert("gpt-5-nano", "opencode/gpt-5-nano");
     map.insert("minimax-m2.5-free", "opencode/minimax-m2.5-free");
+    // Default: NVIDIA hybrid Mamba-Transformer (hive-mind issue #1563, agent PR #243)
+    map.insert("nemotron-3-super-free", "opencode/nemotron-3-super-free");
     // Kilo Gateway free models
     map.insert("glm-5-free", "kilo/glm-5-free");
     map.insert("glm-4.5-air-free", "kilo/glm-4.5-air-free");
@@ -24,6 +26,7 @@ pub fn get_model_map() -> HashMap<&'static str, &'static str> {
     map.insert("giga-potato-free", "kilo/giga-potato-free");
     map.insert("trinity-large-preview", "kilo/trinity-large-preview");
     // Deprecated free models (kept for backward compatibility)
+    map.insert("qwen3.6-plus-free", "opencode/qwen3.6-plus-free"); // Deprecated: free promotion ended April 2026
     map.insert("kimi-k2.5-free", "opencode/kimi-k2.5-free");
     map.insert("glm-4.7-free", "opencode/glm-4.7-free");
     map.insert("minimax-m2.1-free", "opencode/minimax-m2.1-free");
@@ -298,7 +301,7 @@ impl Default for AgentTool {
             supports_system_prompt: false, // System prompt is combined with user prompt
             supports_resume: false,    // Agent doesn't have explicit resume like Claude
             supports_read_only: false, // No native enforceable read-only mode
-            default_model: "minimax-m2.5-free",
+            default_model: "nemotron-3-super-free", // hive-mind issue #1563, agent PR #243
         }
     }
 }

--- a/rust/src/tools/claude.rs
+++ b/rust/src/tools/claude.rs
@@ -9,19 +9,21 @@ use std::collections::HashMap;
 pub fn get_model_map() -> HashMap<&'static str, &'static str> {
     let mut map = HashMap::new();
     map.insert("sonnet", "claude-sonnet-4-6");
-    map.insert("opus", "claude-opus-4-6");
+    map.insert("opus", "claude-opus-4-7"); // Opus 4.7 (hive-mind issue #1620, PR #1621)
     map.insert("haiku", "claude-haiku-4-5-20251001");
     map.insert("haiku-3-5", "claude-3-5-haiku-20241022");
     map.insert("haiku-3", "claude-3-haiku-20240307");
     map.insert("opusplan", "opusplan"); // Special mode: Opus for planning, Sonnet for execution
                                         // Shorter version aliases
     map.insert("sonnet-4-6", "claude-sonnet-4-6");
+    map.insert("opus-4-7", "claude-opus-4-7");
     map.insert("opus-4-6", "claude-opus-4-6");
     map.insert("opus-4-5", "claude-opus-4-5-20251101");
     map.insert("sonnet-4-5", "claude-sonnet-4-5-20250929"); // Backward compatibility
     map.insert("haiku-4-5", "claude-haiku-4-5-20251001");
     // Full model ID aliases for backward compatibility
     map.insert("claude-sonnet-4-6", "claude-sonnet-4-6");
+    map.insert("claude-opus-4-7", "claude-opus-4-7");
     map.insert("claude-opus-4-6", "claude-opus-4-6");
     map.insert("claude-opus-4-5", "claude-opus-4-5-20251101");
     map.insert("claude-sonnet-4-5", "claude-sonnet-4-5-20250929");

--- a/rust/src/tools/codex.rs
+++ b/rust/src/tools/codex.rs
@@ -9,11 +9,30 @@ use std::collections::HashMap;
 pub fn get_model_map() -> HashMap<&'static str, &'static str> {
     let mut map = HashMap::new();
     map.insert("gpt5", "gpt-5");
+    map.insert("gpt-5", "gpt-5");
     map.insert("gpt5-codex", "gpt-5-codex");
+    // GPT-5.5 family (hive-mind PR #1657, default)
+    map.insert("gpt-5.5", "gpt-5.5");
+    map.insert("gpt-5.5-mini", "gpt-5.5-mini");
+    map.insert("gpt-5.5-nano", "gpt-5.5-nano");
+    // GPT-5.4 family
+    map.insert("gpt-5.4", "gpt-5.4");
+    map.insert("gpt-5.4-mini", "gpt-5.4-mini");
+    map.insert("gpt-5.4-nano", "gpt-5.4-nano");
+    // GPT-5.3 family (codex variants)
+    map.insert("gpt-5.3-codex", "gpt-5.3-codex");
+    map.insert("gpt-5.3-codex-spark", "gpt-5.3-codex-spark");
+    // GPT-5.2 family
+    map.insert("gpt-5.2", "gpt-5.2");
+    map.insert("gpt-5.2-codex", "gpt-5.2-codex");
+    // GPT-5.1 family
+    map.insert("gpt-5.1-codex-max", "gpt-5.1-codex-max");
     map.insert("o3", "o3");
     map.insert("o3-mini", "o3-mini");
     map.insert("gpt4", "gpt-4");
+    map.insert("gpt-4", "gpt-4");
     map.insert("gpt4o", "gpt-4o");
+    map.insert("gpt-4o", "gpt-4o");
     map.insert("claude", "claude-3-5-sonnet");
     map.insert("sonnet", "claude-3-5-sonnet");
     map.insert("opus", "claude-3-opus");
@@ -238,7 +257,7 @@ impl Default for CodexTool {
             supports_system_prompt: false, // System prompt is combined with user prompt
             supports_resume: true,
             supports_read_only: true, // Supports --sandbox read-only
-            default_model: "gpt-5",
+            default_model: "gpt-5.5", // hive-mind PR #1657
         }
     }
 }

--- a/rust/tests/agent_tests.rs
+++ b/rust/tests/agent_tests.rs
@@ -123,7 +123,24 @@ fn test_agent_tool_default() {
     assert!(tool.supports_json_input);
     assert!(!tool.supports_system_prompt);
     assert!(!tool.supports_resume);
-    assert_eq!(tool.default_model, "minimax-m2.5-free");
+    assert_eq!(tool.default_model, "nemotron-3-super-free");
+}
+
+#[test]
+fn test_map_model_to_id_nemotron_3_super_free() {
+    assert_eq!(
+        map_model_to_id("nemotron-3-super-free"),
+        "opencode/nemotron-3-super-free"
+    );
+}
+
+#[test]
+fn test_map_model_to_id_keeps_deprecated_qwen() {
+    // Deprecated but kept for backward compatibility
+    assert_eq!(
+        map_model_to_id("qwen3.6-plus-free"),
+        "opencode/qwen3.6-plus-free"
+    );
 }
 
 #[test]

--- a/rust/tests/claude_tests.rs
+++ b/rust/tests/claude_tests.rs
@@ -7,8 +7,16 @@ use agent_commander::tools::claude::{
 #[test]
 fn test_map_model_to_id_with_alias() {
     assert_eq!(map_model_to_id("sonnet"), "claude-sonnet-4-6");
-    assert_eq!(map_model_to_id("opus"), "claude-opus-4-6");
+    assert_eq!(map_model_to_id("opus"), "claude-opus-4-7");
     assert_eq!(map_model_to_id("haiku"), "claude-haiku-4-5-20251001");
+}
+
+#[test]
+fn test_map_model_to_id_with_opus_4_7_alias() {
+    assert_eq!(map_model_to_id("opus-4-7"), "claude-opus-4-7");
+    assert_eq!(map_model_to_id("claude-opus-4-7"), "claude-opus-4-7");
+    // Backward compatibility - opus-4-6 still maps explicitly
+    assert_eq!(map_model_to_id("opus-4-6"), "claude-opus-4-6");
 }
 
 #[test]
@@ -92,7 +100,7 @@ fn test_build_args_with_fallback_model() {
     };
     let args = build_args(&options);
     assert!(args.contains(&"--model".to_string()));
-    assert!(args.contains(&"claude-opus-4-6".to_string()));
+    assert!(args.contains(&"claude-opus-4-7".to_string()));
     assert!(args.contains(&"--fallback-model".to_string()));
     assert!(args.contains(&"claude-sonnet-4-6".to_string()));
 }

--- a/rust/tests/codex_tests.rs
+++ b/rust/tests/codex_tests.rs
@@ -93,7 +93,18 @@ fn test_codex_tool_default() {
     assert!(tool.supports_json_input);
     assert!(!tool.supports_system_prompt);
     assert!(tool.supports_resume);
-    assert_eq!(tool.default_model, "gpt-5");
+    assert_eq!(tool.default_model, "gpt-5.5");
+}
+
+#[test]
+fn test_map_model_to_id_gpt_5_5_family() {
+    assert_eq!(map_model_to_id("gpt-5.5"), "gpt-5.5");
+    assert_eq!(map_model_to_id("gpt-5.5-mini"), "gpt-5.5-mini");
+    assert_eq!(map_model_to_id("gpt-5.5-nano"), "gpt-5.5-nano");
+    assert_eq!(map_model_to_id("gpt-5.4"), "gpt-5.4");
+    assert_eq!(map_model_to_id("gpt-5.3-codex"), "gpt-5.3-codex");
+    assert_eq!(map_model_to_id("gpt-5.2-codex"), "gpt-5.2-codex");
+    assert_eq!(map_model_to_id("gpt-5.1-codex-max"), "gpt-5.1-codex-max");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Closes #22.

This PR brings agent-commander up to date with [hive-mind](https://github.com/link-assistant/hive-mind) **v1.57.2** (release 2026-04-26). The previous full sync was on 2026-04-05 in PR #18 (issue #17), so this iteration covers ~3 weeks of upstream evolution. It also delivers the analysis of the experimental Claude bidirectional JSON I/O work and files the upstream issue needed before that pattern can be replicated for `@link-assistant/agent`.

## Changes

### Model maps (JS + Rust)

- **Claude**: `opus` → `claude-opus-4-7` (was `claude-opus-4-6`); add `opus-4-7` and `claude-opus-4-7` aliases. `opus-4-6` retained for backward compatibility. (Mirrors hive-mind PR #1621.)
- **Codex**: add the `gpt-5.5/5.4/5.3/5.2/5.1` family (`gpt-5.5`, `gpt-5.5-mini`, `gpt-5.5-nano`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2`, `gpt-5.2-codex`, `gpt-5.1-codex-max`); default model `gpt-5` → `gpt-5.5`. (Mirrors hive-mind PR #1657.)
- **Agent**: add `nemotron-3-super-free` (NVIDIA hybrid Mamba-Transformer); default `minimax-m2.5-free` → `nemotron-3-super-free`; mark `qwen3.6-plus-free` as deprecated (kept for backward compatibility). (Mirrors hive-mind PR #1564 / agent PR #243.)
- **OpenCode / Qwen / Gemini**: no model changes (no upstream drift).

### Bidirectional JSON I/O — investigation

Hive-mind's [`bidirectional-interactive.lib.mjs`](https://github.com/link-assistant/hive-mind/blob/main/src/bidirectional-interactive.lib.mjs) (~710 lines) explicitly says: _"Currently only supported for Claude due to `--input-format stream-json` support."_ agent-commander already builds the right Claude flags (`--input-format stream-json`, `--replay-user-messages`) and has the NDJSON building blocks in `src/streaming/`. The 710-line live driver itself belongs to the execution layer and is intentionally **not** ported (consistent with the [issue #17 case study](docs/case-studies/issue-17/README.md)).

For the other CLIs, `--input-format stream-json` parity is upstream-blocked. Filed [link-assistant/agent#268](https://github.com/link-assistant/agent/issues/268) requesting this for `@link-assistant/agent`. Codex bidirectional support requires upstream OpenAI work — no agent-commander-side action until they expose it.

### Documentation

- New case study: [`docs/case-studies/issue-22/README.md`](docs/case-studies/issue-22/README.md) covering: requirements, sync timeline, hive-mind diff summary (model maps + tool features + execution-layer changes), bidirectional I/O matrix, recommendations, sources.
- README "Supported Tools" table updated to reflect the new defaults (`gpt-5.5` for codex, `nemotron-3-super-free` for agent) and the corrected Claude opus full ID.
- Changesets added under `js/.changeset/` and `rust/changelog.d/` for the next release.

## Test plan

- [x] `npm test` — 155/155 pass (3 new claude alias tests, 2 new codex `gpt-5.5` family tests, 3 new agent `nemotron` tests, plus updates to existing assertions).
- [x] `cargo test` — 207/207 pass (mirrored Rust tests).
- [x] `cargo fmt --check` — clean.
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] Manual `start-agent --tool codex --dry-run --model gpt-5.5 --prompt x` shows the new model in the rendered command.

## Out of scope (next sync)

These are listed in the case study under "Future-sync candidates":

- Pull `unicode-sanitization.lib.mjs` (~67 lines) into `parseOutput`.
- Pull `parseModelWith1mSuffix` and `MODELS_SUPPORTING_1M_CONTEXT` for Claude `[1m]` 1M-token context.
- Pull `getCodexErrorEventSummary` (~100 lines) for richer Codex error parsing.
- Centralize model maps into `js/src/tools/models.mjs` (mirror hive-mind's `src/models/index.mjs` pattern) so future syncs are diff-friendly.
- Pull `defaultFallbackModels` (Claude `opus-4-7 → opus-4-6`, Codex chain) so callers can opt into auto-retry on overload.

## Related

- Issue: https://github.com/link-assistant/agent-commander/issues/22
- Previous sync: PR #18 / issue #17 (2026-04-05)
- Filed during this PR: https://github.com/link-assistant/agent/issues/268