### PR TITLE
Support hive-mind prompt-file execution

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-30T08:23:09.961Z for PR creation at branch issue-27-f689ab66c37e for issue https://github.com/link-assistant/agent-commander/issues/27

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-30T08:23:09.961Z for PR creation at branch issue-27-f689ab66c37e for issue https://github.com/link-assistant/agent-commander/issues/27

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Language-specific package documentation:
 - **Dry Run Mode**: Preview commands before execution
 - **Attached/Detached Modes**: Monitor output in real-time or run in background
 - **Read-only Planning Mode**: Enforce native no-shell/no-write restrictions for supported tools
+- **Prompt File Input**: Pipe large prompts through files for stdin-based tools instead of embedding them in shell commands
 
 ## Installation
 
@@ -152,6 +153,7 @@ start-agent --tool claude --working-directory "/tmp/dir" --prompt "Solve the iss
 - `--tool <name>` - CLI tool to use (e.g., 'claude', 'codex', 'opencode', 'qwen', 'gemini', 'agent') [required]
 - `--working-directory <path>` - Working directory for the agent [required]
 - `--prompt <text>` - Prompt for the agent
+- `--prompt-file <path>` - Read prompt input from a file
 - `--system-prompt <text>` - System prompt for the agent
 - `--append-system-prompt <text>` - Append to the default system prompt (Claude only)
 - `--model <name>` - Model to use (e.g., 'sonnet', 'opus', 'grok')
@@ -182,6 +184,13 @@ start-agent --tool claude --working-directory "/tmp/dir" --prompt "Hello" --mode
 
 ```bash
 start-agent --tool codex --working-directory "/tmp/dir" --prompt "Fix the bug" --model gpt5
+```
+
+**Using a prompt file for large prompts**
+
+```bash
+start-agent --tool codex --working-directory "/tmp/dir" \
+  --prompt-file /tmp/agent-prompt.txt --model gpt-5.5
 ```
 
 **Using @link-assistant/agent with Grok**

--- a/docs/case-studies/issue-27/README.md
+++ b/docs/case-studies/issue-27/README.md
@@ -1,0 +1,143 @@
+# Case Study: Hive-Mind `--use-agent-commander` Support (Issue #27)
+
+## Problem Statement
+
+Issue #27 asked for `agent-commander` to support the requirements introduced by hive-mind PR 1044, which adds an experimental `--use-agent-commander` path. The work needed to verify the full hive-mind `src` tree, keep JavaScript and Rust behavior aligned, and document the compatibility evidence.
+
+## Evidence Collected
+
+- agent-commander issue: https://github.com/link-assistant/agent-commander/issues/27
+- agent-commander PR: https://github.com/link-assistant/agent-commander/pull/28
+- hive-mind PR 1044: https://github.com/link-assistant/hive-mind/pull/1044
+- hive-mind PR 1044 source branch inspected locally at `/tmp/hive-mind-1044`
+- hive-mind current code search for `agent-commander`, `start-agent`, and `--prompt-subagents-via-agent-commander`
+- Online references:
+  - Node.js `child_process.spawn()` documents command-plus-argument spawning, shell handling risks, and stdin pipes: https://nodejs.org/api/child_process.html
+  - IBM `getconf` documentation records `ARG_MAX` as the maximum argument length for running a program, including environment data: https://www.ibm.com/docs/en/zos/2.5.0?topic=descriptions-getconf-get-configuration-values
+
+## Hive-Mind Source Inventory
+
+The PR 1044 branch contained 65 files in `src` totaling 27,606 lines. Every file was included in the source review; files that directly affect agent-commander integration are marked "direct".
+
+| Lines | File | Relevance |
+| ---: | --- | --- |
+| 365 | `agent-commander.lib.mjs` | direct: imports `agent()` / `isToolSupported()` and runs tools through agent-commander |
+| 684 | `agent.lib.mjs` | direct: native @link-assistant/agent runner baseline |
+| 189 | `agent.prompts.lib.mjs` | prompt expectations |
+| 58 | `buildUserMention.lib.mjs` | issue/user mention formatting |
+| 792 | `claude-limits.lib.mjs` | Claude usage/rate-limit parsing |
+| 50 | `claude.budget-stats.lib.mjs` | Claude budget parsing |
+| 89 | `claude.command-builder.lib.mjs` | direct: native Claude command shape |
+| 1500 | `claude.lib.mjs` | direct: native Claude execution baseline |
+| 206 | `claude.prompts.lib.mjs` | direct: start-agent prompt guidance on main branch |
+| 520 | `codex.lib.mjs` | direct: native Codex execution baseline |
+| 197 | `codex.prompts.lib.mjs` | direct: start-agent prompt guidance on main branch |
+| 194 | `config.lib.mjs` | config plumbing |
+| 255 | `contributing-guidelines.lib.mjs` | prompt context input |
+| 205 | `exit-handler.lib.mjs` | shutdown behavior |
+| 145 | `git.lib.mjs` | repository state handling |
+| 246 | `github-issue-creator.lib.mjs` | GitHub issue workflows |
+| 127 | `github-linking.lib.mjs` | GitHub URL parsing |
+| 276 | `github.batch.lib.mjs` | GitHub batching |
+| 258 | `github.graphql.lib.mjs` | GitHub GraphQL access |
+| 1497 | `github.lib.mjs` | issue/PR data collection |
+| 290 | `hive.config.lib.mjs` | direct: `--use-agent-commander` config on PR 1044 |
+| 1500 | `hive.mjs` | direct: hive CLI flag passthrough |
+| 187 | `instrument.mjs` | telemetry wrapper |
+| 974 | `interactive-mode.lib.mjs` | interactive prompting |
+| 201 | `lenv-reader.lib.mjs` | environment loading |
+| 481 | `lib.mjs` | shared utilities |
+| 176 | `lino.lib.mjs` | line-oriented output |
+| 32 | `list-solution-drafts.lib.mjs` | solution draft listing |
+| 325 | `local-ci-checks.lib.mjs` | verification commands |
+| 411 | `memory-check.mjs` | runtime memory guard |
+| 138 | `model-mapping.lib.mjs` | direct: model alias expectations |
+| 278 | `model-validation.lib.mjs` | direct: model validation expectations |
+| 541 | `opencode.lib.mjs` | direct: native OpenCode execution baseline |
+| 188 | `opencode.prompts.lib.mjs` | prompt expectations |
+| 158 | `protect-branch.mjs` | branch protection |
+| 434 | `review.mjs` | PR review command |
+| 638 | `reviewers-hive.mjs` | reviewer orchestration |
+| 287 | `sentry.lib.mjs` | error reporting |
+| 581 | `solve.auto-continue.lib.mjs` | auto-continue flow |
+| 1493 | `solve.auto-pr.lib.mjs` | PR creation/update flow |
+| 312 | `solve.branch-errors.lib.mjs` | branch error handling |
+| 228 | `solve.branch.lib.mjs` | branch setup |
+| 429 | `solve.config.lib.mjs` | direct: `--use-agent-commander` config on PR 1044 |
+| 198 | `solve.error-handlers.lib.mjs` | solve error handling |
+| 283 | `solve.execution.lib.mjs` | solve execution flow |
+| 430 | `solve.feedback.lib.mjs` | feedback loop |
+| 1312 | `solve.mjs` | direct: solve CLI flag passthrough |
+| 185 | `solve.preparation.lib.mjs` | context preparation |
+| 99 | `solve.repo-setup.lib.mjs` | repo setup |
+| 1198 | `solve.repository.lib.mjs` | repository cloning/fetching |
+| 719 | `solve.results.lib.mjs` | result parsing |
+| 120 | `solve.session.lib.mjs` | session state |
+| 336 | `solve.validation.lib.mjs` | solve validation |
+| 575 | `solve.watch.lib.mjs` | watch mode |
+| 324 | `start-screen.mjs` | screen helper |
+| 302 | `task.mjs` | direct on current main: uses `start-agent` for subagent prompts |
+| 1485 | `telegram-bot.mjs` | Telegram integration |
+| 64 | `telegram-markdown.lib.mjs` | Telegram formatting |
+| 309 | `telegram-top-command.lib.mjs` | Telegram commands |
+| 214 | `usage-limit.lib.mjs` | usage-limit parsing |
+| 529 | `version-info.lib.mjs` | version reporting |
+| 41 | `version.lib.mjs` | version constants |
+| 111 | `youtrack/solve.youtrack.lib.mjs` | YouTrack solve flow |
+| 214 | `youtrack/youtrack-sync.mjs` | YouTrack sync CLI |
+| 423 | `youtrack/youtrack.lib.mjs` | YouTrack API helpers |
+
+## Requirements Extracted
+
+1. Keep `agent({ tool, workingDirectory, prompt, systemPrompt, model, json, resume })` compatible with PR 1044's `agent-commander.lib.mjs` wrapper.
+2. Preserve `start({ dryRun, attached, onOutput })`, `stop()`, `getSessionId()`, parsed output, usage extraction, and exit-code behavior.
+3. Support hive-mind tools `claude`, `codex`, `opencode`, and `agent` with model mapping, resume support where native tools provide it, and read-only support where enforceable.
+4. Keep JavaScript and Rust public behavior aligned.
+5. Avoid embedding large generated prompts in nested shell command strings.
+6. Document the compatibility analysis and add regression coverage.
+
+## Root Cause
+
+The PR 1044 wrapper passes full solve prompts into `agent()` in memory. Before this fix, `agent-commander` rebuilt those prompts into shell command strings:
+
+- `codex`, `opencode`, and `agent` used inline `printf '%s' '...' | tool`.
+- `claude` used `--prompt "..."`.
+- All tool commands were nested inside `bash -c "cd ... && ..."`.
+
+That was fragile for hive-mind solve prompts because shell metacharacters must survive multiple quoting layers, and very large prompts can exceed the operating system's argument budget. The online `ARG_MAX` and Node child-process references confirm that process launches are bounded by command/argument size and that stdin is the appropriate channel for large child-process input.
+
+## Solution Implemented
+
+- Added `promptFile` / `prompt_file` / `--prompt-file` support.
+- Added automatic temporary prompt-file creation for in-memory prompts when the tool reads prompt input from stdin.
+- For `codex`, `opencode`, and `agent`, temporary prompt files contain `systemPrompt`, a blank line, and `prompt`.
+- For `claude`, temporary prompt files contain `prompt`; `systemPrompt` remains a Claude CLI argument to preserve existing semantics.
+- Added cleanup for temporary prompt directories after process completion or stop.
+- Added JavaScript and Rust tests that launch a fake `agent` executable with a 3 MiB shell-sensitive prompt and assert the exact stdin byte count.
+- Added command-builder tests proving prompt content is not embedded when `promptFile` is supplied.
+- Updated README/common-concepts docs plus JavaScript and Rust release fragments.
+
+## Verification
+
+Reproducing checks before the fix:
+
+| Check | Result |
+| --- | --- |
+| `node --test js/test/command-builder.test.mjs` | Failed as expected before implementation because prompt-file command support was missing |
+| `cargo test test_build_agent_command_codex_prompt_file --manifest-path rust/Cargo.toml` | Failed as expected before implementation because Rust command options had no `prompt_file` field |
+
+Final local verification:
+
+| Check | Result |
+| --- | --- |
+| `npm test` from `js/` | Pass, 164 tests |
+| `npm run check` from `js/` | Pass, 0 errors; lint complexity/size findings are warning-only in this project |
+| `bun test` from `js/` | Pass, 164 tests |
+| `deno test --allow-read --allow-run --allow-env --allow-net test/**/*.test.mjs` from `js/` | Pass, 163 passed and 1 ignored because the large-prompt fake executable test requires write permission that the Deno CI job does not grant |
+| `cargo fmt --all -- --check` from `rust/` | Pass |
+| `cargo clippy --all-targets --all-features` from `rust/` | Pass |
+| `node ../scripts/rust/check-file-size.mjs` from `rust/` | Pass |
+| `cargo test --all-features --verbose` from `rust/` | Pass |
+| `cargo test --doc --verbose` from `rust/` | Pass |
+| `cargo build --release --verbose` from `rust/` | Pass |
+| `cargo package --list --allow-dirty` from `rust/` | Pass |

--- a/docs/common-concepts.md
+++ b/docs/common-concepts.md
@@ -27,6 +27,14 @@ The shared isolation modes are:
 
 `--dry-run` should print the command that would be executed without starting a process.
 
+## Prompt Input
+
+Both packages accept `--prompt <text>` / `prompt` for short prompts and `--prompt-file <path>` / `promptFile` / `prompt_file` for prompt content already stored on disk.
+
+For `claude`, `codex`, `opencode`, and `agent`, the controllers also write in-memory prompts to temporary files at execution time and pipe those files into stdin. This keeps large generated prompts out of nested shell command strings while preserving the public API used by hive-mind and similar orchestrators.
+
+For `codex`, `opencode`, and `agent`, the temporary file contains the system prompt followed by a blank line and then the user prompt. For `claude`, the temporary file contains the user prompt and the system prompt remains a Claude CLI system-prompt argument.
+
 ## Claude Options
 
 Both packages expose Claude-specific options for model fallback, session management, prompt appending, verbose mode, and replaying user messages:

--- a/js/.changeset/prompt-file-input.md
+++ b/js/.changeset/prompt-file-input.md
@@ -1,0 +1,11 @@
+---
+'agent-commander': patch
+---
+
+### Fixed
+
+- Pipe prompts for stdin-based tools through temporary prompt files during execution so large generated prompts are not embedded in nested shell commands.
+
+### Added
+
+- Added `--prompt-file` / `promptFile` support for callers that already have prompt content on disk.

--- a/js/README.md
+++ b/js/README.md
@@ -48,6 +48,7 @@ Common options:
 - `--tool <name>`: `claude`, `codex`, `opencode`, `qwen`, `gemini`, or `agent`
 - `--working-directory <path>`: directory where the agent command runs
 - `--prompt <text>` and `--system-prompt <text>`: user and system prompts
+- `--prompt-file <path>`: read prompt input from a file for stdin-based tools
 - `--model <name>`: tool-specific model alias or full model name
 - `--read-only` or `--plan-only`: enforce native planning/no-write mode when supported
 - `--isolation <mode>`: `none`, `screen`, or `docker`
@@ -73,6 +74,17 @@ const result = await controller.stop();
 
 console.log(result.exitCode);
 console.log(result.output.plain);
+```
+
+For large generated prompts, pass `promptFile` or let the controller create a temporary prompt file automatically for `claude`, `codex`, `opencode`, and `agent`:
+
+```javascript
+const controller = agent({
+  tool: 'codex',
+  workingDirectory: '/tmp/project',
+  promptFile: '/tmp/agent-prompt.txt',
+  model: 'gpt-5.5',
+});
 ```
 
 Pass tool-specific options through `toolOptions`:

--- a/js/bin/start-agent.mjs
+++ b/js/bin/start-agent.mjs
@@ -37,6 +37,7 @@ async function main() {
       tool: options.tool,
       workingDirectory: options.workingDirectory,
       prompt: options.prompt,
+      promptFile: options.promptFile,
       systemPrompt: options.systemPrompt,
       model: options.model,
       resume: options.resume,

--- a/js/src/cli-parser.mjs
+++ b/js/src/cli-parser.mjs
@@ -47,6 +47,7 @@ export function parseStartAgentArgs(args) {
     tool: parsed.tool,
     workingDirectory: parsed['working-directory'],
     prompt: parsed.prompt,
+    promptFile: parsed['prompt-file'],
     systemPrompt: parsed['system-prompt'],
     appendSystemPrompt: parsed['append-system-prompt'],
     model: parsed.model,
@@ -95,6 +96,7 @@ Options:
   --tool <name>                    CLI tool to use (e.g., 'claude') [required]
   --working-directory <path>       Working directory for the agent [required]
   --prompt <text>                  Prompt for the agent
+  --prompt-file <path>             Read prompt input from a file
   --system-prompt <text>           System prompt for the agent
   --append-system-prompt <text>    Append to the default system prompt
   --model <model>                  Model to use (e.g., 'sonnet', 'opus', 'haiku')

--- a/js/src/command-builder.mjs
+++ b/js/src/command-builder.mjs
@@ -10,6 +10,7 @@ import { isToolSupported, getTool } from './tools/index.mjs';
  * @param {string} options.tool - The CLI tool to use (e.g., 'claude', 'codex', 'opencode', 'agent')
  * @param {string} options.workingDirectory - Working directory path
  * @param {string} [options.prompt] - Prompt for the agent
+ * @param {string} [options.promptFile] - File containing prompt input for stdin-based tools
  * @param {string} [options.systemPrompt] - System prompt for the agent
  * @param {string} [options.model] - Model to use (tool-specific)
  * @param {boolean} [options.json] - Enable JSON output mode
@@ -26,6 +27,7 @@ export function buildAgentCommand(options) {
     tool,
     workingDirectory,
     prompt,
+    promptFile,
     systemPrompt,
     model,
     json,
@@ -51,6 +53,7 @@ export function buildAgentCommand(options) {
       baseCommand = toolConfig.buildCommand({
         workingDirectory,
         prompt,
+        promptFile,
         systemPrompt,
         model,
         json,

--- a/js/src/index.mjs
+++ b/js/src/index.mjs
@@ -9,6 +9,9 @@
  * - agent: @link-assistant/agent (unrestricted OpenCode fork)
  */
 
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   buildAgentCommand,
   buildScreenStopCommand,
@@ -22,6 +25,59 @@ import {
 } from './executor.mjs';
 import { getTool, isToolSupported } from './tools/index.mjs';
 import { createOutputStream, createInputStream } from './streaming/index.mjs';
+
+const PROMPT_FILE_TOOLS = new Set(['claude', 'codex', 'opencode', 'agent']);
+
+/**
+ * Determine whether the tool can read prompt input from stdin.
+ * @param {string} toolName - Tool name
+ * @returns {boolean} True when prompt files can be piped into the tool
+ */
+function supportsPromptFileInput(toolName) {
+  return PROMPT_FILE_TOOLS.has(toolName);
+}
+
+/**
+ * Build the prompt content to write to a temporary stdin file.
+ * @param {Object} options - Options
+ * @param {string} options.toolName - Tool name
+ * @param {string} [options.prompt] - User prompt
+ * @param {string} [options.systemPrompt] - System prompt
+ * @returns {string} Prompt file content
+ */
+function buildPromptFileContent(options) {
+  const { toolName, prompt, systemPrompt } = options;
+
+  if (toolName === 'claude') {
+    return prompt || '';
+  }
+
+  return systemPrompt ? `${systemPrompt}\n\n${prompt || ''}` : prompt || '';
+}
+
+/**
+ * Return true when a temporary prompt file should replace inline shell input.
+ * @param {Object} options - Options
+ * @param {string} options.toolName - Tool name
+ * @param {string} [options.prompt] - User prompt
+ * @param {string} [options.systemPrompt] - System prompt
+ * @param {string} [options.promptFile] - Existing prompt file
+ * @param {boolean} [options.dryRun] - Dry-run mode
+ * @returns {boolean} True when a temporary prompt file should be created
+ */
+function shouldCreatePromptFile(options) {
+  const { toolName, prompt, systemPrompt, promptFile, dryRun } = options;
+
+  if (dryRun || promptFile || !supportsPromptFileInput(toolName)) {
+    return false;
+  }
+
+  if (toolName === 'claude') {
+    return Boolean(prompt);
+  }
+
+  return Boolean(prompt || systemPrompt);
+}
 
 /**
  * Parse JSON messages from output if the tool supports it
@@ -75,6 +131,7 @@ function parseJsonMessages(options) {
  * @param {string} options.tool - CLI tool to use (e.g., 'claude', 'codex', 'opencode', 'agent')
  * @param {string} options.workingDirectory - Working directory for the agent
  * @param {string} [options.prompt] - Prompt for the agent
+ * @param {string} [options.promptFile] - File containing prompt input for stdin-based tools
  * @param {string} [options.systemPrompt] - System prompt for the agent
  * @param {string} [options.model] - Model to use (tool-specific)
  * @param {string} [options.isolation='none'] - Isolation mode: 'none', 'screen', 'docker'
@@ -91,6 +148,7 @@ export function agent(options) {
     tool,
     workingDirectory,
     prompt,
+    promptFile,
     systemPrompt,
     model,
     isolation = 'none',
@@ -126,6 +184,40 @@ export function agent(options) {
   let command = null;
   let outputStream = null;
   let sessionId = null;
+  let promptTempDir = null;
+
+  const cleanupPromptTempDir = async () => {
+    if (!promptTempDir) {
+      return;
+    }
+
+    const dir = promptTempDir;
+    promptTempDir = null;
+    await rm(dir, { recursive: true, force: true });
+  };
+
+  const preparePromptFile = async (startOptions) => {
+    if (
+      !shouldCreatePromptFile({
+        toolName: tool,
+        prompt,
+        systemPrompt,
+        promptFile,
+        dryRun: startOptions.dryRun,
+      })
+    ) {
+      return promptFile;
+    }
+
+    promptTempDir = await mkdtemp(join(tmpdir(), 'agent-commander-'));
+    const tempPromptFile = join(promptTempDir, 'prompt.txt');
+    await writeFile(
+      tempPromptFile,
+      buildPromptFileContent({ toolName: tool, prompt, systemPrompt }),
+      { mode: 0o600 }
+    );
+    return tempPromptFile;
+  };
 
   /**
    * Start the agent (non-blocking)
@@ -153,74 +245,86 @@ export function agent(options) {
       });
     }
 
-    // Build the command with tool-specific options
-    const commandOptions = {
-      tool,
-      workingDirectory,
-      prompt,
-      systemPrompt,
-      isolation,
-      screenName,
-      containerName,
-      detached,
-      readOnly,
-    };
+    try {
+      const preparedPromptFile = await preparePromptFile({ dryRun });
+      const promptHandledByTempFile = preparedPromptFile && !promptFile;
 
-    // Add tool-specific options if tool is known
-    if (toolConfig) {
-      commandOptions.model = model;
-      commandOptions.json = json;
-      commandOptions.resume = resume;
-      Object.assign(commandOptions, toolOptions);
-    }
+      // Build the command with tool-specific options
+      const commandOptions = {
+        tool,
+        workingDirectory,
+        prompt: promptHandledByTempFile ? undefined : prompt,
+        promptFile: preparedPromptFile,
+        systemPrompt:
+          promptHandledByTempFile && tool !== 'claude'
+            ? undefined
+            : systemPrompt,
+        isolation,
+        screenName,
+        containerName,
+        detached,
+        readOnly,
+      };
 
-    command = buildAgentCommand(commandOptions);
-
-    if (dryRun) {
-      console.log('Dry run - command that would be executed:');
-      console.log(command);
-      return;
-    }
-
-    // Setup signal handler for graceful shutdown
-    if (!detached && isolation === 'none') {
-      removeSignalHandler = setupSignalHandler(async () => {
-        console.log('Propagating shutdown to agent...');
-        // The process will be terminated naturally by SIGINT
-      });
-    }
-
-    if (detached) {
-      // For detached mode, use executeDetached
-      processHandle = await executeDetached(command);
-      console.log(`Agent started in detached mode`);
-      if (isolation === 'screen') {
-        console.log(`Screen session: ${screenName}`);
-      } else if (isolation === 'docker') {
-        console.log(`Container: ${containerName}`);
+      // Add tool-specific options if tool is known
+      if (toolConfig) {
+        commandOptions.model = model;
+        commandOptions.json = json;
+        commandOptions.resume = resume;
+        Object.assign(commandOptions, toolOptions);
       }
-    } else {
-      // For attached mode, start command without waiting
-      const commandOptions = { attached };
 
-      // Add output handling for streaming
-      if (onOutput) {
-        commandOptions.onStdout = (chunk) => {
-          onOutput({ type: 'stdout', data: chunk });
-          if (outputStream) {
+      command = buildAgentCommand(commandOptions);
+
+      if (dryRun) {
+        console.log('Dry run - command that would be executed:');
+        console.log(command);
+        return;
+      }
+
+      // Setup signal handler for graceful shutdown
+      if (!detached && isolation === 'none') {
+        removeSignalHandler = setupSignalHandler(() => {
+          console.log('Propagating shutdown to agent...');
+          // The process will be terminated naturally by SIGINT
+        });
+      }
+
+      if (detached) {
+        // For detached mode, use executeDetached
+        processHandle = await executeDetached(command);
+        console.log(`Agent started in detached mode`);
+        if (isolation === 'screen') {
+          console.log(`Screen session: ${screenName}`);
+        } else if (isolation === 'docker') {
+          console.log(`Container: ${containerName}`);
+        }
+      } else {
+        // For attached mode, start command without waiting
+        const commandOptions = { attached };
+
+        // Add output handling for streaming
+        if (onOutput) {
+          commandOptions.onStdout = (chunk) => {
+            onOutput({ type: 'stdout', data: chunk });
+            if (outputStream) {
+              outputStream.process({ chunk });
+            }
+          };
+          commandOptions.onStderr = (chunk) => {
+            onOutput({ type: 'stderr', data: chunk });
+          };
+        } else if (outputStream) {
+          commandOptions.onStdout = (chunk) => {
             outputStream.process({ chunk });
-          }
-        };
-        commandOptions.onStderr = (chunk) => {
-          onOutput({ type: 'stderr', data: chunk });
-        };
-      } else if (outputStream) {
-        commandOptions.onStdout = (chunk) => {
-          outputStream.process({ chunk });
-        };
-      }
+          };
+        }
 
-      processHandle = await startCommand(command, commandOptions);
+        processHandle = await startCommand(command, commandOptions);
+      }
+    } catch (error) {
+      await cleanupPromptTempDir();
+      throw error;
     }
   };
 
@@ -254,17 +358,21 @@ export function agent(options) {
         return { exitCode: 0, output: { plain: '', parsed: null } };
       }
 
-      const result = await executeCommand(stopCommand, {
-        dryRun,
-        attached: true,
-      });
-      return {
-        exitCode: result.exitCode,
-        output: {
-          plain: result.stdout,
-          parsed: null, // Stop commands don't produce parsed output
-        },
-      };
+      try {
+        const result = await executeCommand(stopCommand, {
+          dryRun,
+          attached: true,
+        });
+        return {
+          exitCode: result.exitCode,
+          output: {
+            plain: result.stdout,
+            parsed: null, // Stop commands don't produce parsed output
+          },
+        };
+      } finally {
+        await cleanupPromptTempDir();
+      }
     }
 
     // For no isolation, wait for process to complete and collect output
@@ -273,55 +381,59 @@ export function agent(options) {
         throw new Error('Agent not started or already stopped');
       }
 
-      // Wait for the process to exit
-      const exitCode = await processHandle.waitForExit();
-      const { stdout, stderr } = processHandle.getOutput();
+      try {
+        // Wait for the process to exit
+        const exitCode = await processHandle.waitForExit();
+        const { stdout, stderr } = processHandle.getOutput();
 
-      // Combine stdout and stderr for plain output
-      const plainOutput = stdout + (stderr ? `\n${stderr}` : '');
+        // Combine stdout and stderr for plain output
+        const plainOutput = stdout + (stderr ? `\n${stderr}` : '');
 
-      // Flush output stream if we have one
-      if (outputStream) {
-        outputStream.flush();
+        // Flush output stream if we have one
+        if (outputStream) {
+          outputStream.flush();
+        }
+
+        // Try to parse JSON messages (use output stream messages if available, otherwise parse)
+        let parsedOutput;
+        if (outputStream && outputStream.getMessages().length > 0) {
+          parsedOutput = outputStream.getMessages();
+        } else {
+          parsedOutput = parseJsonMessages({
+            output: plainOutput,
+            toolName: tool,
+          });
+        }
+
+        // Extract session ID if tool supports it
+        if (toolConfig && toolConfig.extractSessionId) {
+          sessionId = toolConfig.extractSessionId({ output: plainOutput });
+        }
+
+        // Extract usage if tool supports it
+        let usage = null;
+        if (toolConfig && toolConfig.extractUsage) {
+          usage = toolConfig.extractUsage({ output: plainOutput });
+        }
+
+        // Clean up signal handler
+        if (removeSignalHandler) {
+          removeSignalHandler();
+          removeSignalHandler = null;
+        }
+
+        return {
+          exitCode,
+          output: {
+            plain: plainOutput,
+            parsed: parsedOutput,
+          },
+          sessionId,
+          usage,
+        };
+      } finally {
+        await cleanupPromptTempDir();
       }
-
-      // Try to parse JSON messages (use output stream messages if available, otherwise parse)
-      let parsedOutput;
-      if (outputStream && outputStream.getMessages().length > 0) {
-        parsedOutput = outputStream.getMessages();
-      } else {
-        parsedOutput = parseJsonMessages({
-          output: plainOutput,
-          toolName: tool,
-        });
-      }
-
-      // Extract session ID if tool supports it
-      if (toolConfig && toolConfig.extractSessionId) {
-        sessionId = toolConfig.extractSessionId({ output: plainOutput });
-      }
-
-      // Extract usage if tool supports it
-      let usage = null;
-      if (toolConfig && toolConfig.extractUsage) {
-        usage = toolConfig.extractUsage({ output: plainOutput });
-      }
-
-      // Clean up signal handler
-      if (removeSignalHandler) {
-        removeSignalHandler();
-        removeSignalHandler = null;
-      }
-
-      return {
-        exitCode,
-        output: {
-          plain: plainOutput,
-          parsed: parsedOutput,
-        },
-        sessionId,
-        usage,
-      };
     }
 
     throw new Error(`Unsupported isolation mode: ${isolation}`);

--- a/js/src/tools/agent.mjs
+++ b/js/src/tools/agent.mjs
@@ -98,6 +98,7 @@ export function buildArgs(options) {
  * @param {Object} options - Options
  * @param {string} options.workingDirectory - Working directory
  * @param {string} [options.prompt] - User prompt
+ * @param {string} [options.promptFile] - File containing combined prompt input
  * @param {string} [options.systemPrompt] - System prompt
  * @param {string} [options.model] - Model to use
  * @param {boolean} [options.compactJson] - Use compact JSON output
@@ -106,7 +107,8 @@ export function buildArgs(options) {
  */
 export function buildCommand(options) {
   // eslint-disable-next-line no-unused-vars
-  const { workingDirectory, prompt, systemPrompt, ...argOptions } = options;
+  const { workingDirectory, prompt, promptFile, systemPrompt, ...argOptions } =
+    options;
   const args = buildArgs(argOptions);
 
   // Agent expects prompt via stdin, combine system and user prompts
@@ -115,8 +117,10 @@ export function buildCommand(options) {
     : prompt || '';
 
   // Build command with stdin piping
-  const escapedPrompt = combinedPrompt.replace(/'/g, "'\\''");
-  return `printf '%s' '${escapedPrompt}' | agent ${args.map(escapeArg).join(' ')}`.trim();
+  const inputCommand = promptFile
+    ? `cat ${escapeArg(promptFile)}`
+    : `printf '%s' '${combinedPrompt.replace(/'/g, "'\\''")}'`;
+  return `${inputCommand} | agent ${args.map(escapeArg).join(' ')}`.trim();
 }
 
 /**

--- a/js/src/tools/claude.mjs
+++ b/js/src/tools/claude.mjs
@@ -153,6 +153,7 @@ export function buildArgs(options) {
  * @param {Object} options - Options
  * @param {string} options.workingDirectory - Working directory
  * @param {string} [options.prompt] - User prompt
+ * @param {string} [options.promptFile] - File containing prompt input
  * @param {string} [options.systemPrompt] - System prompt
  * @param {string} [options.appendSystemPrompt] - System prompt to append to default
  * @param {string} [options.model] - Model to use
@@ -170,9 +171,18 @@ export function buildArgs(options) {
  */
 export function buildCommand(options) {
   // eslint-disable-next-line no-unused-vars
-  const { workingDirectory, ...argOptions } = options;
-  const args = buildArgs(argOptions);
-  return `claude ${args.map(escapeArg).join(' ')}`.trim();
+  const { workingDirectory, prompt, promptFile, ...argOptions } = options;
+  const args = buildArgs({
+    ...argOptions,
+    prompt: promptFile ? undefined : prompt,
+  });
+  const command = `claude ${args.map(escapeArg).join(' ')}`.trim();
+
+  if (promptFile) {
+    return `cat ${escapeArg(promptFile)} | ${command}`;
+  }
+
+  return command;
 }
 
 /**

--- a/js/src/tools/codex.mjs
+++ b/js/src/tools/codex.mjs
@@ -95,6 +95,7 @@ export function buildArgs(options) {
  * @param {Object} options - Options
  * @param {string} options.workingDirectory - Working directory
  * @param {string} [options.prompt] - User prompt
+ * @param {string} [options.promptFile] - File containing combined prompt input
  * @param {string} [options.systemPrompt] - System prompt
  * @param {string} [options.model] - Model to use
  * @param {boolean} [options.json] - JSON output mode
@@ -104,7 +105,8 @@ export function buildArgs(options) {
  */
 export function buildCommand(options) {
   // eslint-disable-next-line no-unused-vars
-  const { workingDirectory, prompt, systemPrompt, ...argOptions } = options;
+  const { workingDirectory, prompt, promptFile, systemPrompt, ...argOptions } =
+    options;
   const args = buildArgs(argOptions);
 
   // Codex expects prompt via stdin, combine system and user prompts
@@ -113,11 +115,13 @@ export function buildCommand(options) {
     : prompt || '';
 
   // Build command with stdin piping
-  const escapedPrompt = combinedPrompt.replace(/'/g, "'\\''");
+  const inputCommand = promptFile
+    ? `cat ${escapeArg(promptFile)}`
+    : `printf '%s' '${combinedPrompt.replace(/'/g, "'\\''")}'`;
   const executable = argOptions.readOnly
     ? 'codex --ask-for-approval never'
     : 'codex';
-  return `printf '%s' '${escapedPrompt}' | ${executable} ${args.map(escapeArg).join(' ')}`.trim();
+  return `${inputCommand} | ${executable} ${args.map(escapeArg).join(' ')}`.trim();
 }
 
 /**

--- a/js/src/tools/opencode.mjs
+++ b/js/src/tools/opencode.mjs
@@ -67,6 +67,7 @@ export function buildArgs(options) {
  * @param {Object} options - Options
  * @param {string} options.workingDirectory - Working directory
  * @param {string} [options.prompt] - User prompt
+ * @param {string} [options.promptFile] - File containing combined prompt input
  * @param {string} [options.systemPrompt] - System prompt
  * @param {string} [options.model] - Model to use
  * @param {boolean} [options.json] - JSON output mode
@@ -75,7 +76,13 @@ export function buildArgs(options) {
  * @returns {string} Complete command string
  */
 export function buildCommand(options) {
-  const { prompt, systemPrompt, readOnly = false, ...argOptions } = options;
+  const {
+    prompt,
+    promptFile,
+    systemPrompt,
+    readOnly = false,
+    ...argOptions
+  } = options;
   const args = buildArgs(argOptions);
 
   // OpenCode expects prompt via stdin, combine system and user prompts
@@ -84,11 +91,13 @@ export function buildCommand(options) {
     : prompt || '';
 
   // Build command with stdin piping
-  const escapedPrompt = combinedPrompt.replace(/'/g, "'\\''");
+  const inputCommand = promptFile
+    ? `cat ${escapeArg(promptFile)}`
+    : `printf '%s' '${combinedPrompt.replace(/'/g, "'\\''")}'`;
   const executable = readOnly
     ? `OPENCODE_PERMISSION='{"edit":"deny","bash":"deny","task":"deny"}' opencode`
     : 'opencode';
-  return `printf '%s' '${escapedPrompt}' | ${executable} ${args.map(escapeArg).join(' ')}`.trim();
+  return `${inputCommand} | ${executable} ${args.map(escapeArg).join(' ')}`.trim();
 }
 
 /**

--- a/js/test/cli-parser.test.mjs
+++ b/js/test/cli-parser.test.mjs
@@ -190,6 +190,20 @@ test('parseStartAgentArgs - with append-system-prompt', () => {
   assert.strictEqual(result.appendSystemPrompt, 'Extra instructions here');
 });
 
+test('parseStartAgentArgs - with prompt-file', () => {
+  const args = [
+    '--tool',
+    'codex',
+    '--working-directory',
+    '/tmp/test',
+    '--prompt-file',
+    '/tmp/prompt.txt',
+  ];
+  const result = parseStartAgentArgs(args);
+
+  assert.strictEqual(result.promptFile, '/tmp/prompt.txt');
+});
+
 test('parseStartAgentArgs - with verbose and replay-user-messages', () => {
   const args = [
     '--tool',
@@ -244,4 +258,5 @@ test('parseStartAgentArgs - defaults for new options', () => {
   assert.strictEqual(result.resume, undefined);
   assert.strictEqual(result.sessionId, undefined);
   assert.strictEqual(result.appendSystemPrompt, undefined);
+  assert.strictEqual(result.promptFile, undefined);
 });

--- a/js/test/command-builder.test.mjs
+++ b/js/test/command-builder.test.mjs
@@ -111,6 +111,43 @@ test('buildAgentCommand - with codex tool', () => {
   assert.ok(command.includes('--json'));
 });
 
+test('buildAgentCommand - codex can read prompt from file', () => {
+  const inlinePrompt = "Secret prompt with 'quotes', $HOME, and `pwd`";
+  const command = buildAgentCommand({
+    tool: 'codex',
+    workingDirectory: '/tmp/test',
+    prompt: inlinePrompt,
+    systemPrompt: 'System instructions',
+    promptFile: '/tmp/agent prompt.txt',
+    isolation: 'none',
+  });
+
+  assert.ok(command.includes('cat'));
+  assert.ok(command.includes('/tmp/agent prompt.txt'));
+  assert.ok(command.includes('codex'));
+  assert.ok(!command.includes(inlinePrompt));
+  assert.ok(!command.includes('System instructions'));
+});
+
+test('buildAgentCommand - claude can read prompt from file', () => {
+  const inlinePrompt = "Secret prompt with 'quotes', $HOME, and `pwd`";
+  const command = buildAgentCommand({
+    tool: 'claude',
+    workingDirectory: '/tmp/test',
+    prompt: inlinePrompt,
+    systemPrompt: 'You are helpful',
+    promptFile: '/tmp/agent prompt.txt',
+    isolation: 'none',
+  });
+
+  assert.ok(command.includes('cat'));
+  assert.ok(command.includes('/tmp/agent prompt.txt'));
+  assert.ok(command.includes('claude'));
+  assert.ok(command.includes('--system-prompt'));
+  assert.ok(command.includes('You are helpful'));
+  assert.ok(!command.includes(inlinePrompt));
+});
+
 test('buildAgentCommand - with agent tool', () => {
   const command = buildAgentCommand({
     tool: 'agent',

--- a/js/test/index.test.mjs
+++ b/js/test/index.test.mjs
@@ -4,7 +4,12 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert';
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { agent } from '../src/index.mjs';
+
+const isDeno = typeof globalThis.Deno !== 'undefined';
 
 test('agent - throws without tool', () => {
   assert.throws(() => {
@@ -117,5 +122,42 @@ test(
     assert.ok(result.output);
     assert.ok(result.output.plain);
     assert.ok(result.output.plain.includes('Hello World'));
+  }
+);
+
+test(
+  'agent - stdin tools handle large shell-sensitive prompts through a file',
+  { skip: process.platform === 'win32' || isDeno },
+  async (t) => {
+    const binDir = await mkdtemp(join(tmpdir(), 'agent-commander-test-bin-'));
+    const fakeAgent = join(binDir, 'agent');
+    await writeFile(
+      fakeAgent,
+      '#!/usr/bin/env bash\nwc -c | tr -d "[:space:]"\n'
+    );
+    await chmod(fakeAgent, 0o755);
+
+    const previousPath = process.env.PATH || '';
+    process.env.PATH = `${binDir}:${previousPath}`;
+    t.after(async () => {
+      process.env.PATH = previousPath;
+      await rm(binDir, { recursive: true, force: true });
+    });
+
+    const prompt = `${'x'.repeat(3 * 1024 * 1024)}\n' "$HOME" \`pwd\``;
+    const systemPrompt = 'system instructions';
+    const expectedBytes = Buffer.byteLength(`${systemPrompt}\n\n${prompt}`);
+    const controller = agent({
+      tool: 'agent',
+      workingDirectory: '/tmp',
+      prompt,
+      systemPrompt,
+    });
+
+    await controller.start({ attached: false });
+    const result = await controller.stop();
+
+    assert.strictEqual(result.exitCode, 0);
+    assert.strictEqual(result.output.plain.trim(), String(expectedBytes));
   }
 );

--- a/rust/README.md
+++ b/rust/README.md
@@ -40,6 +40,7 @@ Common options:
 - `--tool <name>`: `claude`, `codex`, `opencode`, `qwen`, `gemini`, or `agent`
 - `--working-directory <path>`: directory where the agent command runs
 - `--prompt <text>` and `--system-prompt <text>`: user and system prompts
+- `--prompt-file <path>`: read prompt input from a file for stdin-based tools
 - `--model <name>`: tool-specific model alias or full model name
 - `--read-only` or `--plan-only`: enforce native planning/no-write mode when supported
 - `--isolation <mode>`: `none`, `screen`, or `docker`
@@ -76,6 +77,8 @@ async fn main() -> Result<(), String> {
     Ok(())
 }
 ```
+
+For large generated prompts, set `prompt_file` or let the controller create a temporary prompt file automatically for `claude`, `codex`, `opencode`, and `agent`.
 
 ## Shared Behavior
 

--- a/rust/changelog.d/20260430_prompt_file_input.md
+++ b/rust/changelog.d/20260430_prompt_file_input.md
@@ -1,0 +1,11 @@
+---
+bump: patch
+---
+
+### Fixed
+
+- Pipe prompts for stdin-based tools through temporary prompt files during execution so large generated prompts are not embedded in nested shell commands.
+
+### Added
+
+- Added `--prompt-file` / `prompt_file` support for callers that already have prompt content on disk.

--- a/rust/src/bin/start_agent.rs
+++ b/rust/src/bin/start_agent.rs
@@ -33,6 +33,7 @@ async fn main() {
         tool: options.tool.unwrap_or_default(),
         working_directory: options.working_directory.unwrap_or_default(),
         prompt: options.prompt,
+        prompt_file: options.prompt_file,
         system_prompt: options.system_prompt,
         append_system_prompt: options.append_system_prompt,
         model: options.model,

--- a/rust/src/cli_parser.rs
+++ b/rust/src/cli_parser.rs
@@ -73,6 +73,7 @@ pub struct StartAgentOptions {
     pub tool: Option<String>,
     pub working_directory: Option<String>,
     pub prompt: Option<String>,
+    pub prompt_file: Option<String>,
     pub system_prompt: Option<String>,
     pub append_system_prompt: Option<String>,
     pub model: Option<String>,
@@ -122,6 +123,7 @@ pub fn parse_start_agent_args(args: &[String]) -> StartAgentOptions {
         tool: parsed.get("tool").cloned(),
         working_directory: parsed.get("working-directory").cloned(),
         prompt: parsed.get("prompt").cloned(),
+        prompt_file: parsed.get("prompt-file").cloned(),
         system_prompt: parsed.get("system-prompt").cloned(),
         append_system_prompt: parsed.get("append-system-prompt").cloned(),
         model: parsed.get("model").cloned(),
@@ -171,6 +173,7 @@ Options:
   --tool <name>                    CLI tool to use (e.g., 'claude') [required]
   --working-directory <path>       Working directory for the agent [required]
   --prompt <text>                  Prompt for the agent
+  --prompt-file <path>             Read prompt input from a file
   --system-prompt <text>           System prompt for the agent
   --append-system-prompt <text>    Append to the default system prompt
   --model <model>                  Model to use (e.g., 'sonnet', 'opus', 'haiku')
@@ -485,6 +488,21 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_start_agent_args_with_prompt_file() {
+        let args: Vec<String> = vec![
+            "--tool".into(),
+            "codex".into(),
+            "--working-directory".into(),
+            "/tmp/test".into(),
+            "--prompt-file".into(),
+            "/tmp/prompt.txt".into(),
+        ];
+        let result = parse_start_agent_args(&args);
+
+        assert_eq!(result.prompt_file, Some("/tmp/prompt.txt".to_string()));
+    }
+
+    #[test]
     fn test_parse_start_agent_args_with_verbose_and_replay_user_messages() {
         let args: Vec<String> = vec![
             "--tool".into(),
@@ -518,6 +536,7 @@ mod tests {
         assert!(result.resume.is_none());
         assert!(result.session_id.is_none());
         assert!(result.append_system_prompt.is_none());
+        assert!(result.prompt_file.is_none());
     }
 
     #[test]

--- a/rust/src/command_builder.rs
+++ b/rust/src/command_builder.rs
@@ -16,6 +16,7 @@ pub struct AgentCommandOptions {
     pub tool: String,
     pub working_directory: String,
     pub prompt: Option<String>,
+    pub prompt_file: Option<String>,
     pub system_prompt: Option<String>,
     pub append_system_prompt: Option<String>,
     pub model: Option<String>,
@@ -159,6 +160,7 @@ pub fn build_agent_command(options: &AgentCommandOptions) -> String {
         match options.tool.as_str() {
             "claude" => claude::build_command(&ClaudeBuildOptions {
                 prompt: options.prompt.clone(),
+                prompt_file: options.prompt_file.clone(),
                 system_prompt: options.system_prompt.clone(),
                 append_system_prompt: options.append_system_prompt.clone(),
                 model: options.model.clone(),
@@ -175,6 +177,7 @@ pub fn build_agent_command(options: &AgentCommandOptions) -> String {
             }),
             "codex" => codex::build_command(&CodexBuildOptions {
                 prompt: options.prompt.clone(),
+                prompt_file: options.prompt_file.clone(),
                 system_prompt: options.system_prompt.clone(),
                 model: options.model.clone(),
                 json: options.json,
@@ -183,6 +186,7 @@ pub fn build_agent_command(options: &AgentCommandOptions) -> String {
             }),
             "opencode" => opencode::build_command(&OpencodeBuildOptions {
                 prompt: options.prompt.clone(),
+                prompt_file: options.prompt_file.clone(),
                 system_prompt: options.system_prompt.clone(),
                 model: options.model.clone(),
                 json: options.json,
@@ -191,6 +195,7 @@ pub fn build_agent_command(options: &AgentCommandOptions) -> String {
             }),
             "agent" => agent::build_command(&AgentBuildOptions {
                 prompt: options.prompt.clone(),
+                prompt_file: options.prompt_file.clone(),
                 system_prompt: options.system_prompt.clone(),
                 model: options.model.clone(),
                 compact_json: false,
@@ -492,6 +497,50 @@ mod tests {
         assert!(command.contains("codex"));
         assert!(command.contains("exec"));
         assert!(command.contains("--json"));
+    }
+
+    #[test]
+    fn test_build_agent_command_codex_prompt_file() {
+        let inline_prompt = "Secret prompt with 'quotes', $HOME, and `pwd`";
+        let options = AgentCommandOptions {
+            tool: "codex".to_string(),
+            working_directory: "/tmp/test".to_string(),
+            prompt: Some(inline_prompt.to_string()),
+            system_prompt: Some("System instructions".to_string()),
+            prompt_file: Some("/tmp/agent prompt.txt".to_string()),
+            json: true,
+            isolation: "none".to_string(),
+            ..Default::default()
+        };
+
+        let command = build_agent_command(&options);
+        assert!(command.contains("cat"));
+        assert!(command.contains("/tmp/agent prompt.txt"));
+        assert!(command.contains("codex"));
+        assert!(!command.contains(inline_prompt));
+        assert!(!command.contains("System instructions"));
+    }
+
+    #[test]
+    fn test_build_agent_command_claude_prompt_file() {
+        let inline_prompt = "Secret prompt with 'quotes', $HOME, and `pwd`";
+        let options = AgentCommandOptions {
+            tool: "claude".to_string(),
+            working_directory: "/tmp/test".to_string(),
+            prompt: Some(inline_prompt.to_string()),
+            system_prompt: Some("You are helpful".to_string()),
+            prompt_file: Some("/tmp/agent prompt.txt".to_string()),
+            isolation: "none".to_string(),
+            ..Default::default()
+        };
+
+        let command = build_agent_command(&options);
+        assert!(command.contains("cat"));
+        assert!(command.contains("/tmp/agent prompt.txt"));
+        assert!(command.contains("claude"));
+        assert!(command.contains("--system-prompt"));
+        assert!(command.contains("You are helpful"));
+        assert!(!command.contains(inline_prompt));
     }
 
     #[test]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -14,6 +14,9 @@ pub mod streaming;
 pub mod tools;
 
 use serde_json::Value;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::io::AsyncWriteExt;
 
 pub use cli_parser::{
     parse_args, parse_start_agent_args, parse_stop_agent_args, show_start_agent_help,
@@ -50,6 +53,8 @@ pub struct AgentOptions {
     pub working_directory: String,
     /// Prompt for the agent
     pub prompt: Option<String>,
+    /// File containing prompt input for stdin-based tools
+    pub prompt_file: Option<String>,
     /// System prompt for the agent
     pub system_prompt: Option<String>,
     /// Append to the default system prompt (tool-specific)
@@ -117,6 +122,40 @@ pub struct Agent {
     process_handle: Option<ProcessHandle>,
     output_stream: Option<JsonOutputStream>,
     session_id: Option<String>,
+    prompt_temp_dir: Option<PathBuf>,
+}
+
+fn supports_prompt_file_input(tool: &str) -> bool {
+    matches!(tool, "claude" | "codex" | "opencode" | "agent")
+}
+
+fn build_prompt_file_content(
+    tool: &str,
+    prompt: Option<&str>,
+    system_prompt: Option<&str>,
+) -> String {
+    if tool == "claude" {
+        return prompt.unwrap_or_default().to_string();
+    }
+
+    match (system_prompt, prompt) {
+        (Some(system_prompt), Some(prompt)) => format!("{}\n\n{}", system_prompt, prompt),
+        (Some(system_prompt), None) => system_prompt.to_string(),
+        (None, Some(prompt)) => prompt.to_string(),
+        (None, None) => String::new(),
+    }
+}
+
+fn should_create_prompt_file(options: &AgentOptions, dry_run: bool) -> bool {
+    if dry_run || options.prompt_file.is_some() || !supports_prompt_file_input(&options.tool) {
+        return false;
+    }
+
+    if options.tool == "claude" {
+        return options.prompt.is_some();
+    }
+
+    options.prompt.is_some() || options.system_prompt.is_some()
 }
 
 impl Agent {
@@ -150,7 +189,56 @@ impl Agent {
             process_handle: None,
             output_stream: None,
             session_id: None,
+            prompt_temp_dir: None,
         })
+    }
+
+    async fn cleanup_prompt_temp_dir(&mut self) {
+        if let Some(dir) = self.prompt_temp_dir.take() {
+            let _ = tokio::fs::remove_dir_all(dir).await;
+        }
+    }
+
+    async fn prepare_prompt_file(&mut self, dry_run: bool) -> Result<Option<String>, String> {
+        if !should_create_prompt_file(&self.options, dry_run) {
+            return Ok(self.options.prompt_file.clone());
+        }
+
+        let unique_id = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|e| e.to_string())?
+            .as_nanos();
+        let temp_dir = std::env::temp_dir().join(format!(
+            "agent-commander-{}-{}",
+            std::process::id(),
+            unique_id
+        ));
+        tokio::fs::create_dir(&temp_dir)
+            .await
+            .map_err(|e| e.to_string())?;
+        self.prompt_temp_dir = Some(temp_dir.clone());
+        let prompt_file = temp_dir.join("prompt.txt");
+        let content = build_prompt_file_content(
+            &self.options.tool,
+            self.options.prompt.as_deref(),
+            self.options.system_prompt.as_deref(),
+        );
+
+        let mut open_options = tokio::fs::OpenOptions::new();
+        open_options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            open_options.mode(0o600);
+        }
+        let mut file = open_options
+            .open(&prompt_file)
+            .await
+            .map_err(|e| e.to_string())?;
+        file.write_all(content.as_bytes())
+            .await
+            .map_err(|e| e.to_string())?;
+
+        Ok(Some(prompt_file.to_string_lossy().into_owned()))
     }
 
     /// Start the agent (non-blocking)
@@ -166,12 +254,31 @@ impl Agent {
             self.output_stream = Some(create_output_stream());
         }
 
+        let prepared_prompt_file = match self.prepare_prompt_file(start_options.dry_run).await {
+            Ok(prompt_file) => prompt_file,
+            Err(error) => {
+                self.cleanup_prompt_temp_dir().await;
+                return Err(error);
+            }
+        };
+        let prompt_handled_by_temp_file =
+            prepared_prompt_file.is_some() && self.options.prompt_file.is_none();
+
         // Build the command
         let command_options = AgentCommandOptions {
             tool: self.options.tool.clone(),
             working_directory: self.options.working_directory.clone(),
-            prompt: self.options.prompt.clone(),
-            system_prompt: self.options.system_prompt.clone(),
+            prompt: if prompt_handled_by_temp_file {
+                None
+            } else {
+                self.options.prompt.clone()
+            },
+            prompt_file: prepared_prompt_file,
+            system_prompt: if prompt_handled_by_temp_file && self.options.tool != "claude" {
+                None
+            } else {
+                self.options.system_prompt.clone()
+            },
             append_system_prompt: self.options.append_system_prompt.clone(),
             model: self.options.model.clone(),
             fallback_model: self.options.fallback_model.clone(),
@@ -198,9 +305,10 @@ impl Agent {
 
         if start_options.detached {
             // For detached mode, use execute_detached
-            execute_detached(&command)
-                .await
-                .map_err(|e| e.to_string())?;
+            if let Err(error) = execute_detached(&command).await.map_err(|e| e.to_string()) {
+                self.cleanup_prompt_temp_dir().await;
+                return Err(error);
+            }
             println!("Agent started in detached mode");
             if self.options.isolation == "screen" {
                 if let Some(ref name) = self.options.screen_name {
@@ -213,9 +321,16 @@ impl Agent {
             }
         } else {
             // For attached mode, start command without waiting
-            let handle = start_command(&command, start_options.attached)
+            let handle = match start_command(&command, start_options.attached)
                 .await
-                .map_err(|e| e.to_string())?;
+                .map_err(|e| e.to_string())
+            {
+                Ok(handle) => handle,
+                Err(error) => {
+                    self.cleanup_prompt_temp_dir().await;
+                    return Err(error);
+                }
+            };
             self.process_handle = Some(handle);
         }
 
@@ -254,9 +369,17 @@ impl Agent {
                 return Ok(AgentResult::default());
             }
 
-            let result = execute_command(&stop_command, false, true)
+            let result = match execute_command(&stop_command, false, true)
                 .await
-                .map_err(|e| e.to_string())?;
+                .map_err(|e| e.to_string())
+            {
+                Ok(result) => result,
+                Err(error) => {
+                    self.cleanup_prompt_temp_dir().await;
+                    return Err(error);
+                }
+            };
+            self.cleanup_prompt_temp_dir().await;
 
             return Ok(AgentResult {
                 exit_code: result.exit_code,
@@ -268,13 +391,23 @@ impl Agent {
 
         // For no isolation, wait for process to complete and collect output
         if self.options.isolation == "none" || self.options.isolation.is_empty() {
+            if self.process_handle.is_none() {
+                self.cleanup_prompt_temp_dir().await;
+                return Err("Agent not started or already stopped".to_string());
+            }
             let handle = self
                 .process_handle
                 .as_mut()
                 .ok_or("Agent not started or already stopped")?;
 
             // Wait for the process to exit
-            let exit_code = handle.wait_for_exit().await.map_err(|e| e.to_string())?;
+            let exit_code = match handle.wait_for_exit().await.map_err(|e| e.to_string()) {
+                Ok(exit_code) => exit_code,
+                Err(error) => {
+                    self.cleanup_prompt_temp_dir().await;
+                    return Err(error);
+                }
+            };
 
             let (stdout, stderr, _) = handle.get_output();
 
@@ -315,12 +448,14 @@ impl Agent {
                 }
             }
 
-            return Ok(AgentResult {
+            let result = AgentResult {
                 exit_code,
                 plain_output,
                 parsed_output,
                 session_id: self.session_id.clone(),
-            });
+            };
+            self.cleanup_prompt_temp_dir().await;
+            return Ok(result);
         }
 
         Err(format!(

--- a/rust/src/tools/agent.rs
+++ b/rust/src/tools/agent.rs
@@ -57,6 +57,7 @@ pub fn map_model_to_id(model: &str) -> String {
 #[derive(Debug, Clone, Default)]
 pub struct AgentBuildOptions {
     pub prompt: Option<String>,
+    pub prompt_file: Option<String>,
     pub system_prompt: Option<String>,
     pub model: Option<String>,
     pub compact_json: bool,
@@ -135,14 +136,13 @@ pub fn build_command(options: &AgentBuildOptions) -> String {
     };
 
     // Build command with stdin piping
-    let escaped_prompt = escape_single_quotes(&combined_prompt);
-    format!(
-        "printf '%s' '{}' | agent {}",
-        escaped_prompt,
-        args_str.join(" ")
-    )
-    .trim()
-    .to_string()
+    let input_command = options.prompt_file.as_ref().map_or_else(
+        || format!("printf '%s' '{}'", escape_single_quotes(&combined_prompt)),
+        |prompt_file| format!("cat {}", escape_arg(prompt_file)),
+    );
+    format!("{} | agent {}", input_command, args_str.join(" "))
+        .trim()
+        .to_string()
 }
 
 /// Parse JSON messages from Agent output

--- a/rust/src/tools/claude.rs
+++ b/rust/src/tools/claude.rs
@@ -50,6 +50,7 @@ pub fn map_model_to_id(model: &str) -> String {
 #[derive(Debug, Clone, Default)]
 pub struct ClaudeBuildOptions {
     pub prompt: Option<String>,
+    pub prompt_file: Option<String>,
     pub system_prompt: Option<String>,
     pub append_system_prompt: Option<String>,
     pub model: Option<String>,
@@ -102,9 +103,11 @@ pub fn build_args(options: &ClaudeBuildOptions) -> Vec<String> {
         args.push(mapped_fallback);
     }
 
-    if let Some(ref prompt) = options.prompt {
-        args.push("--prompt".to_string());
-        args.push(prompt.clone());
+    if options.prompt_file.is_none() {
+        if let Some(ref prompt) = options.prompt {
+            args.push("--prompt".to_string());
+            args.push(prompt.clone());
+        }
     }
 
     if let Some(ref system_prompt) = options.system_prompt {
@@ -189,7 +192,13 @@ fn escape_arg(arg: &str) -> String {
 pub fn build_command(options: &ClaudeBuildOptions) -> String {
     let args = build_args(options);
     let args_str: Vec<String> = args.iter().map(|a| escape_arg(a)).collect();
-    format!("claude {}", args_str.join(" ")).trim().to_string()
+    let command = format!("claude {}", args_str.join(" ")).trim().to_string();
+
+    if let Some(prompt_file) = &options.prompt_file {
+        format!("cat {} | {}", escape_arg(prompt_file), command)
+    } else {
+        command
+    }
 }
 
 /// Parse JSON messages from Claude output

--- a/rust/src/tools/codex.rs
+++ b/rust/src/tools/codex.rs
@@ -58,6 +58,7 @@ pub fn map_model_to_id(model: &str) -> String {
 #[derive(Debug, Clone, Default)]
 pub struct CodexBuildOptions {
     pub prompt: Option<String>,
+    pub prompt_file: Option<String>,
     pub system_prompt: Option<String>,
     pub model: Option<String>,
     pub json: bool,
@@ -148,21 +149,19 @@ pub fn build_command(options: &CodexBuildOptions) -> String {
     };
 
     // Build command with stdin piping
-    let escaped_prompt = escape_single_quotes(&combined_prompt);
+    let input_command = options.prompt_file.as_ref().map_or_else(
+        || format!("printf '%s' '{}'", escape_single_quotes(&combined_prompt)),
+        |prompt_file| format!("cat {}", escape_arg(prompt_file)),
+    );
     let executable = if options.read_only {
         "codex --ask-for-approval never"
     } else {
         "codex"
     };
 
-    format!(
-        "printf '%s' '{}' | {} {}",
-        escaped_prompt,
-        executable,
-        args_str.join(" ")
-    )
-    .trim()
-    .to_string()
+    format!("{} | {} {}", input_command, executable, args_str.join(" "))
+        .trim()
+        .to_string()
 }
 
 /// Parse JSON messages from Codex output

--- a/rust/src/tools/opencode.rs
+++ b/rust/src/tools/opencode.rs
@@ -42,6 +42,7 @@ pub fn map_model_to_id(model: &str) -> String {
 #[derive(Debug, Clone, Default)]
 pub struct OpencodeBuildOptions {
     pub prompt: Option<String>,
+    pub prompt_file: Option<String>,
     pub system_prompt: Option<String>,
     pub model: Option<String>,
     pub json: bool,
@@ -124,21 +125,19 @@ pub fn build_command(options: &OpencodeBuildOptions) -> String {
     };
 
     // Build command with stdin piping
-    let escaped_prompt = escape_single_quotes(&combined_prompt);
+    let input_command = options.prompt_file.as_ref().map_or_else(
+        || format!("printf '%s' '{}'", escape_single_quotes(&combined_prompt)),
+        |prompt_file| format!("cat {}", escape_arg(prompt_file)),
+    );
     let executable = if options.read_only {
         format!("OPENCODE_PERMISSION='{}' opencode", READ_ONLY_PERMISSION)
     } else {
         "opencode".to_string()
     };
 
-    format!(
-        "printf '%s' '{}' | {} {}",
-        escaped_prompt,
-        executable,
-        args_str.join(" ")
-    )
-    .trim()
-    .to_string()
+    format!("{} | {} {}", input_command, executable, args_str.join(" "))
+        .trim()
+        .to_string()
 }
 
 /// Parse JSON messages from OpenCode output

--- a/rust/tests/lib_tests.rs
+++ b/rust/tests/lib_tests.rs
@@ -2,6 +2,20 @@
 
 use agent_commander::{agent, AgentOptions, AgentStartOptions, AgentStopOptions};
 
+#[cfg(not(target_os = "windows"))]
+struct PathGuard {
+    previous_path: String,
+    temp_dir: std::path::PathBuf,
+}
+
+#[cfg(not(target_os = "windows"))]
+impl Drop for PathGuard {
+    fn drop(&mut self) {
+        std::env::set_var("PATH", &self.previous_path);
+        let _ = std::fs::remove_dir_all(&self.temp_dir);
+    }
+}
+
 #[test]
 fn test_agent_throws_without_tool() {
     let options = AgentOptions {
@@ -139,6 +153,7 @@ fn test_agent_options_default() {
     assert!(options.isolation.is_empty());
     assert!(!options.json);
     assert!(options.prompt.is_none());
+    assert!(options.prompt_file.is_none());
     assert!(options.model.is_none());
     assert!(options.fallback_model.is_none());
     assert!(!options.verbose);
@@ -228,4 +243,63 @@ async fn test_agent_start_and_stop_with_no_isolation() {
 
     assert_eq!(result.exit_code, 0);
     assert!(result.plain_output.contains("Hello World"));
+}
+
+#[tokio::test]
+#[cfg(not(target_os = "windows"))]
+async fn test_agent_stdin_tools_handle_large_shell_sensitive_prompts_through_file() {
+    let temp_dir = std::env::temp_dir().join(format!(
+        "agent-commander-test-bin-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&temp_dir).unwrap();
+    let fake_agent = temp_dir.join("agent");
+    std::fs::write(
+        &fake_agent,
+        "#!/usr/bin/env bash\nwc -c | tr -d \"[:space:]\"\n",
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = std::fs::metadata(&fake_agent).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&fake_agent, permissions).unwrap();
+    }
+
+    let previous_path = std::env::var("PATH").unwrap_or_default();
+    std::env::set_var("PATH", format!("{}:{}", temp_dir.display(), previous_path));
+    let _path_guard = PathGuard {
+        previous_path,
+        temp_dir,
+    };
+
+    let prompt = format!("{}\n' \"$HOME\" `pwd`", "x".repeat(3 * 1024 * 1024));
+    let system_prompt = "system instructions".to_string();
+    let expected_bytes = format!("{}\n\n{}", system_prompt, prompt).len();
+    let options = AgentOptions {
+        tool: "agent".to_string(),
+        working_directory: "/tmp".to_string(),
+        prompt: Some(prompt),
+        system_prompt: Some(system_prompt),
+        isolation: "none".to_string(),
+        ..Default::default()
+    };
+    let mut controller = agent(options).unwrap();
+
+    controller
+        .start(AgentStartOptions {
+            attached: false,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    let result = controller.stop(AgentStopOptions::default()).await.unwrap();
+
+    assert_eq!(result.exit_code, 0);
+    assert_eq!(result.plain_output.trim(), expected_bytes.to_string());
 }


### PR DESCRIPTION
Fixes #27.

## Summary

- Reviewed hive-mind PR 1044 and the full hive-mind `src` tree, with compatibility notes recorded in `docs/case-studies/issue-27/README.md`.
- Added `--prompt-file` / `promptFile` / `prompt_file` support in the JavaScript and Rust CLIs and libraries.
- Route in-memory prompts for `claude`, `codex`, `opencode`, and `agent` through temporary prompt files at execution time so large hive-mind prompts are not embedded in nested shell command strings.
- Added JavaScript and Rust regression tests using a fake `agent` executable and a 3 MiB shell-sensitive prompt.

## Reproduction

Before the implementation, prompt-file command-builder coverage failed because the command builders embedded prompt text instead of reading from a file. Rust coverage also failed before adding the `prompt_file` field to command options.

## Verification

- `npm test` from `js/`
- `npm run check` from `js/` (passes with warning-only complexity/size lint findings)
- `bun test` from `js/`
- `deno test --allow-read --allow-run --allow-env --allow-net test/**/*.test.mjs` from `js/` (163 passed, 1 ignored because Deno CI has no write permission for the fake executable integration test)
- `cargo fmt --all -- --check` from `rust/`
- `cargo clippy --all-targets --all-features` from `rust/`
- `node ../scripts/rust/check-file-size.mjs` from `rust/`
- `cargo test --all-features --verbose` from `rust/`
- `cargo test --doc --verbose` from `rust/`
- `cargo build --release --verbose` from `rust/`
- `cargo package --list --allow-dirty` from `rust/`
