### PR TITLE
fix: usage-limit false positive from 'ratelimit' in stream-json header names

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-09T22:48:10.472Z for PR creation at branch issue-37-412bfc0d3e5a for issue https://github.com/link-assistant/agent-commander/issues/37

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-09T22:48:10.472Z for PR creation at branch issue-37-412bfc0d3e5a for issue https://github.com/link-assistant/agent-commander/issues/37

--- a/js/.changeset/fix-ratelimit-false-positive.md
+++ b/js/.changeset/fix-ratelimit-false-positive.md
@@ -1,0 +1,5 @@
+---
+'agent-commander': patch
+---
+
+Fix `metadata.success=false` / `metadata.limitReached=true` false positives on successful Claude runs. The usage-limit detector no longer matches the bare `ratelimit` substring inside Anthropic HTTP header names (e.g. `anthropic-ratelimit-unified-5h-reset`) emitted in `--output-format stream-json`, and now trusts an explicit structured `result` success message over the raw-text scan.

--- a/js/src/result-metadata.mjs
+++ b/js/src/result-metadata.mjs
@@ -1,6 +1,10 @@
 const USAGE_LIMIT_PATTERNS = [
   /usage limit (?:reached|exceeded)/i,
-  /rate[_\s-]?limit(?:ed| reached| exceeded)?/i,
+  // Require an explicit qualifier so a bare "ratelimit" does not match. The raw
+  // stream-json output emitted by Claude contains HTTP header names such as
+  // "anthropic-ratelimit-unified-5h-reset", which previously triggered a false
+  // positive on every successful run. See issue #37.
+  /rate[_\s-]?limit(?:ed|\s+reached|\s+exceeded)/i,
   /limit reached/i,
   /billing hard limit/i,
   /please try again at/i,
@@ -72,8 +76,37 @@ function cleanResetTime(value) {
   return cleaned;
 }
 
-function detectUsageLimit(plainOutput) {
+function findFinalResultMessage(messages) {
+  for (const message of [...messages].reverse()) {
+    if (message && typeof message === 'object' && message.type === 'result') {
+      return message;
+    }
+  }
+  return null;
+}
+
+// A structured result message that reports an explicit success is authoritative.
+// The raw stream-json output contains HTTP header names (e.g.
+// "anthropic-ratelimit-unified-5h-reset") that can match usage-limit patterns
+// even on a fully successful run, so trust this signal over the text scan when
+// it is available. See issue #37.
+function hasStructuredSuccess(messages) {
+  const resultMessage = findFinalResultMessage(messages);
+  return Boolean(
+    resultMessage &&
+    resultMessage.is_error !== true &&
+    (resultMessage.subtype === 'success' ||
+      resultMessage.terminal_reason === 'completed')
+  );
+}
+
+function detectUsageLimit({ plainOutput, messages = [] }) {
   const output = plainOutput || '';
+
+  if (hasStructuredSuccess(messages)) {
+    return { reached: false, resetTime: null, timezone: null };
+  }
+
   const reached = USAGE_LIMIT_PATTERNS.some((pattern) => pattern.test(output));
   let resetTime = null;
   let timezone = null;
@@ -377,7 +410,7 @@ export function buildNormalizedResultMetadata(options) {
     toolConfig = null,
   } = options;
   const messages = normalizeMessages({ parsedOutput, plainOutput, toolConfig });
-  const usageLimit = detectUsageLimit(plainOutput);
+  const usageLimit = detectUsageLimit({ plainOutput, messages });
   const error = detectExecutionError({
     exitCode,
     plainOutput,

--- a/js/test/result-metadata.test.mjs
+++ b/js/test/result-metadata.test.mjs
@@ -81,3 +81,81 @@ test('result metadata - exposes Agent pricing and sub-agent calls', () => {
   assert.strictEqual(metadata.subAgentCalls.length, 1);
   assert.strictEqual(metadata.subAgentCalls[0].id, 'call-1');
 });
+
+test('result metadata - does not flag success as limit on ratelimit header names', () => {
+  // Regression test for issue #37: Claude's stream-json output includes HTTP
+  // response header names such as "anthropic-ratelimit-unified-5h-reset". These
+  // must not be misread as a usage-limit signal on a fully successful run.
+  const plainOutput = [
+    '{"type":"system","subtype":"init","session_id":"sess-1"}',
+    JSON.stringify({
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        usage: {
+          input_tokens: 10,
+          output_tokens: 1,
+        },
+      },
+      raw_headers: {
+        'anthropic-ratelimit-unified-5h-reset': '2026-06-09T23:00:00Z',
+        'anthropic-ratelimit-requests-remaining': '999',
+      },
+    }),
+    JSON.stringify({
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      result: '7',
+      stop_reason: 'end_turn',
+      terminal_reason: 'completed',
+    }),
+  ].join('\n');
+
+  const metadata = buildNormalizedResultMetadata({
+    tool: 'claude',
+    exitCode: 0,
+    plainOutput,
+  });
+
+  assert.strictEqual(metadata.success, true);
+  assert.strictEqual(metadata.limitReached, false);
+  assert.strictEqual(metadata.limitResetTime, null);
+  assert.strictEqual(metadata.errorDuringExecution, false);
+  assert.strictEqual(metadata.resultSummary, '7');
+});
+
+test('result metadata - bare ratelimit substring does not match pattern', () => {
+  // Without any structured success message, the tightened pattern must still
+  // ignore a bare "ratelimit" substring (e.g. inside a header name).
+  const metadata = buildNormalizedResultMetadata({
+    tool: 'claude',
+    exitCode: 0,
+    plainOutput:
+      'logged header anthropic-ratelimit-unified-5h-reset during request',
+  });
+
+  assert.strictEqual(metadata.success, true);
+  assert.strictEqual(metadata.limitReached, false);
+});
+
+test('result metadata - still detects genuine Claude usage limit', () => {
+  // A real usage-limit run must still be classified as limit reached.
+  const plainOutput = JSON.stringify({
+    type: 'result',
+    subtype: 'error_during_execution',
+    is_error: true,
+    result:
+      'Claude AI usage limit reached. Please try again at 2026-06-10 09:00 UTC.',
+  });
+
+  const metadata = buildNormalizedResultMetadata({
+    tool: 'claude',
+    exitCode: 1,
+    plainOutput,
+  });
+
+  assert.strictEqual(metadata.limitReached, true);
+  assert.strictEqual(metadata.success, false);
+  assert.strictEqual(metadata.limitResetTime, '2026-06-10 09:00 UTC');
+});


### PR DESCRIPTION
## Summary

Fixes #37 — `result.metadata.success` was `false` and `result.metadata.limitReached` was `true` on **fully successful** Claude runs.

`detectUsageLimit()` regex-scanned the entire raw stream-json output and matched the bare substring `ratelimit` inside Anthropic HTTP response **header names** (e.g. `anthropic-ratelimit-unified-5h-reset`), which Claude emits under `--output-format stream-json`. That flipped `success` → `false` and `limitReached` → `true` on every successful run.

## Root cause

`js/src/result-metadata.mjs`:

```js
/rate[_\s-]?limit(?:ed| reached| exceeded)?/i  // trailing `?` makes the qualifier optional → matches bare "ratelimit"
```

`success` / `limitReached` were derived purely from this raw-text scan, so the header-name substring produced a false positive.

## Fix

1. **Tighten the rate-limit pattern** — the qualifier (`ed` / `reached` / `exceeded`) is now required, so a bare `ratelimit` (as in `anthropic-ratelimit-*` header names) no longer matches.
2. **Prefer the structured signal** — when the tool emits an explicit success `result` message (`subtype: "success"` / `terminal_reason: "completed"` and `is_error !== true`), trust it and skip the unreliable raw-text scan entirely.

Genuine usage-limit runs are still detected (the text scan and reset-time extraction are unchanged for non-success results).

## How to reproduce

The reproduction from the issue (`agent({ tool: 'claude', model: 'haiku', json: true, ... })` on an image prompt) previously returned `metadata.success === false` / `metadata.limitReached === true` despite `exitCode === 0` and a `subtype: "success"` result message.

## Tests

Added regression tests in `js/test/result-metadata.test.mjs`:

- `does not flag success as limit on ratelimit header names` — stream-json with `anthropic-ratelimit-*` headers + a success result → `success: true`, `limitReached: false`.
- `bare ratelimit substring does not match pattern` — no structured message, raw header substring only → still not flagged.
- `still detects genuine Claude usage limit` — real `usage limit reached` error result → `limitReached: true`, reset time extracted.

All 187 JS tests pass under Node and Bun; lint, format, and duplication checks are clean. A `patch` changeset is included.
