### PR TITLE
Add a uniform per-command approval relay (ask mode)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-06-17T15:20:23.237Z for PR creation at branch issue-39-15508d68b466 for issue https://github.com/link-assistant/agent-commander/issues/39
+# Updated: 2026-06-17T15:44:05.358Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-06-17T15:20:23.237Z for PR creation at branch issue-39-15508d68b466 for issue https://github.com/link-assistant/agent-commander/issues/39
-# Updated: 2026-06-17T15:44:05.358Z

--- a/docs/common-concepts.md
+++ b/docs/common-concepts.md
@@ -17,6 +17,23 @@ Both packages support these tool names:
 
 Unsupported tools can still be executed through the generic command builder, but read-only planning mode is rejected unless the tool has an enforceable native restriction.
 
+## Per-command approval (ask mode)
+
+Both packages support a uniform `--approve-each` flag (alias: `--permission-mode ask`) that asks the consumer to approve each command the agent wants to run, mapping to the backend's native per-command approval mechanism. When the backend exposes a drivable JSON handshake, each native permission request is relayed to the consumer as a normalized `permission_request` NDJSON event (with an opaque `id`, the `tool`, the resolved `command`/`pattern`, a `title`, and a `scope`); the consumer answers with a normalized `permission_response` carrying a decision of `once`, `always`, or `reject`, which is forwarded back to the native CLI in its own wire format.
+
+`scope` documents what an `always`/allow decision attaches to — it deliberately differs per backend, so consumers should not assume a session-wide grant everywhere.
+
+| Tool       | Native mechanism                                       | Scope              | Relay | Notes                                                                                            |
+| ---------- | ------------------------------------------------------ | ------------------ | ----- | ------------------------------------------------------------------------------------------------ |
+| `agent`    | `--permission-mode ask` (+ `--input-format stream-json`) | `session`          | ✅    | Native JSON `permission_request`/`permission_response` protocol; `once` \| `always` \| `reject` map 1:1. |
+| `claude`   | `--permission-mode default` (stream-json `can_use_tool`) | `tool-input`       | ✅    | `control_request`/`control_response` handshake; no session-wide `always`, so `once` and `always` both allow this call. |
+| `codex`    | `--ask-for-approval` (coupled with `--sandbox`)        | `sandbox-coupled`  | ❌    | Approval is coupled with the sandbox policy and not exposed as a tool-agnostic JSON request/response stream. |
+| `qwen`     | `--approval-mode default`                              | `interactive-only` | ❌    | Headless mode has no relayable per-command JSON approval handshake.                              |
+| `gemini`   | `--approval-mode default`                              | `interactive-only` | ❌    | No JSON stdin channel (prompt is passed via `-p`), so approvals cannot be relayed.               |
+| `opencode` | `OPENCODE_PERMISSION` (static `{edit,bash,task}` policy) | `static-policy`    | ❌    | Only a static up-front policy is available; there is no per-command request/response relay.      |
+
+Only `agent` and `claude` can drive the handshake (`relay = ✅`). For every other tool, `--approve-each` is rejected up front with a clear error — the same pattern `--read-only` uses for tools without an enforceable native restriction.
+
 ## Isolation
 
 The shared isolation modes are:

--- a/examples/permission-relay.mjs
+++ b/examples/permission-relay.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+// Demonstrates the uniform per-command approval ("ask" mode) relay.
+//
+// A consumer running an agent with `--approve-each` receives one normalized
+// `permission_request` event per command the agent wants to run, decides
+// `once` | `always` | `reject`, and the matching native response is forwarded
+// back to the CLI's stdin. This script simulates that loop without spawning a
+// real agent by feeding native frames straight into a PermissionRelay.
+//
+// Run: node examples/permission-relay.mjs
+
+import {
+  PermissionRelay,
+  normalizePermissionRequest,
+  PERMISSION_PARITY,
+  supportsAsk,
+} from "../js/src/index.mjs";
+
+// A trivial approval policy: allow reads, ask-once for builds, reject deletes.
+function decide(request) {
+  const command = request.command ?? "";
+  if (/\brm\b|\bdelete\b/.test(command)) return "reject";
+  if (/\bnpm (run )?build\b|\bcargo build\b/.test(command)) return "always";
+  return "once";
+}
+
+for (const tool of ["agent", "claude"]) {
+  console.log(`\n=== ${tool} (supportsAsk=${supportsAsk({ tool })}) ===`);
+
+  const sentToCli = [];
+  const relay = new PermissionRelay({
+    tool,
+    onRequest: (req) => {
+      const decision = decide(req);
+      console.log(`  request: ${req.command ?? req.toolName} -> ${decision}`);
+      return decision;
+    },
+    write: (line) => sentToCli.push(line),
+  });
+
+  // Native frames as each backend emits them.
+  const frames =
+    tool === "agent"
+      ? [
+          {
+            type: "permission_request",
+            permissionID: "p1",
+            tool: "bash",
+            metadata: { command: "npm run build" },
+          },
+          {
+            type: "permission_request",
+            permissionID: "p2",
+            tool: "bash",
+            metadata: { command: "rm -rf dist" },
+          },
+        ]
+      : [
+          {
+            type: "control_request",
+            request_id: "r1",
+            request: {
+              subtype: "can_use_tool",
+              tool_name: "Bash",
+              input: { command: "cargo build" },
+            },
+          },
+          {
+            type: "control_request",
+            request_id: "r2",
+            request: {
+              subtype: "can_use_tool",
+              tool_name: "Bash",
+              input: { command: "rm -rf target" },
+            },
+          },
+        ];
+
+  for (const message of frames) {
+    await relay.handleMessage({ message });
+  }
+
+  console.log("  forwarded to native CLI stdin:");
+  for (const line of sentToCli) console.log(`    ${line}`);
+}
+
+// The same normalization powers the docs parity table.
+console.log("\n=== parity (relayable only) ===");
+for (const row of PERMISSION_PARITY.filter((r) => r.relay)) {
+  console.log(`  ${row.tool}: scope=${row.scope}  via ${row.nativeMechanism}`);
+}
+
+// Spot-check that an unrelated message is ignored (returns null).
+const ignored = normalizePermissionRequest({
+  tool: "agent",
+  message: { type: "step_finish" },
+});
+console.log(`\nnon-permission message normalized to: ${ignored}`);

--- a/js/.changeset/per-command-approval-relay.md
+++ b/js/.changeset/per-command-approval-relay.md
@@ -1,0 +1,5 @@
+---
+'agent-commander': minor
+---
+
+Add a uniform per-command approval relay ("ask" mode). The new `--approve-each` flag (alias `--permission-mode ask`, library `approveEach`) maps to each backend's native per-command approval mechanism and relays native permission prompts to the consumer as normalized `permission_request` NDJSON events (carrying an opaque `id`, `tool`, `command`/`pattern`, `title`, and a `scope`), forwarding the consumer's normalized decision (`once` | `always` | `reject`) back to the native CLI in its own wire format. Supported (relayable) for `agent` (`--permission-mode ask` + `--input-format stream-json`, scope `session`) and `claude` (stream-json `can_use_tool`, scope `tool-input`); rejected with a clear error for `codex`, `qwen`, `gemini`, and `opencode`, which have no drivable JSON handshake. Exposes a `permissions` module (`normalizePermissionRequest`, `buildPermissionResponse`, `PermissionRelay`, `PERMISSION_PARITY`, `supportsAsk`, `ASK_DECISIONS`, `ASK_SCOPE`).

--- a/js/README.md
+++ b/js/README.md
@@ -51,6 +51,7 @@ Common options:
 - `--prompt-file <path>`: read prompt input from a file for stdin-based tools
 - `--model <name>`: tool-specific model alias or full model name
 - `--read-only` or `--plan-only`: enforce native planning/no-write mode when supported
+- `--approve-each` (alias `--permission-mode ask`): approve each command, relaying native permission prompts as normalized NDJSON (supported for `agent` and `claude`)
 - `--tool-executable <path>`: override the native executable for any supported tool
 - `--tool-env <KEY=VALUE>`: add an environment variable to the native tool process, repeatable
 - `--tool-arg <arg>`: append a raw native tool argument, repeatable
@@ -137,8 +138,9 @@ JavaScript and Rust expose the same core concepts:
 - Dry-run command preview
 - JSON/NDJSON output parsing for tools that support it
 - Read-only planning mode for tools with enforceable native restrictions
+- Per-command approval (ask mode) with a normalized `permission_request`/`permission_response` relay for tools with a drivable native handshake
 
-See [shared concepts](../docs/common-concepts.md) for behavior that should stay aligned across both packages.
+See [shared concepts](../docs/common-concepts.md) for behavior that should stay aligned across both packages, including the [per-command approval parity table](../docs/common-concepts.md#per-command-approval-ask-mode).
 
 ## Release Flow
 

--- a/js/bin/start-agent.mjs
+++ b/js/bin/start-agent.mjs
@@ -11,6 +11,57 @@ import {
   showStartAgentHelp,
   validateStartAgentOptions,
 } from '../src/cli-parser.mjs';
+import {
+  parseNdjsonLine,
+  stringifyNdjsonLine,
+} from '../src/streaming/ndjson.mjs';
+
+/**
+ * Build a per-command approval consumer bridge over the process's own stdio.
+ *
+ * The agent controller normalizes each native permission request and hands it
+ * to `onPermissionRequest`. Here we emit that normalized request to stdout as
+ * an NDJSON line and wait for the consumer to reply on stdin with a matching
+ * `{ "type": "permission_response", "id": <id>, "decision": "once|always|reject" }`
+ * frame. The decision is resolved back to the controller, which forwards it to
+ * the native CLI's stdin in the correct wire format.
+ *
+ * @returns {Function} async (normalizedRequest) => 'once' | 'always' | 'reject'
+ */
+function createStdioApprovalBridge() {
+  const pending = new Map();
+  let buffer = '';
+
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', (chunk) => {
+    buffer += chunk;
+    const lines = buffer.split('\n');
+    buffer = lines.pop() || '';
+    for (const line of lines) {
+      const message = parseNdjsonLine({ line });
+      if (
+        message &&
+        message.type === 'permission_response' &&
+        message.id !== null &&
+        message.id !== undefined &&
+        pending.has(message.id)
+      ) {
+        const resolve = pending.get(message.id);
+        pending.delete(message.id);
+        resolve(message.decision);
+      }
+    }
+  });
+
+  return (request) =>
+    new Promise((resolve) => {
+      pending.set(request.id, resolve);
+      // `raw` carries the unnormalized native frame; omit it from the relayed
+      // event so the consumer sees a clean, tool-agnostic request.
+      const { raw: _raw, ...relayed } = request;
+      process.stdout.write(stringifyNdjsonLine({ value: relayed }));
+    });
+}
 
 async function main() {
   const args = process.argv.slice(2);
@@ -32,6 +83,12 @@ async function main() {
   }
 
   try {
+    // When per-command approval is requested, bridge the relay to this
+    // process's stdio so an external consumer can approve/reject each command.
+    const onPermissionRequest = options.approveEach
+      ? createStdioApprovalBridge()
+      : undefined;
+
     // Create agent controller
     const agentController = agent({
       tool: options.tool,
@@ -43,6 +100,8 @@ async function main() {
       resume: options.resume,
       readOnly: options.readOnly,
       planOnly: options.planOnly,
+      approveEach: options.approveEach,
+      onPermissionRequest,
       isolation: options.isolation,
       screenName: options.screenName,
       containerName: options.containerName,

--- a/js/src/cli-parser.mjs
+++ b/js/src/cli-parser.mjs
@@ -91,6 +91,8 @@ export function parseStartAgentArgs(args) {
     replayUserMessages: parsed['replay-user-messages'] || false,
     readOnly: parsed['read-only'] || parsed['plan-only'] || false,
     planOnly: parsed['plan-only'] || false,
+    approveEach:
+      parsed['approve-each'] || parsed['permission-mode'] === 'ask' || false,
     resume: parsed.resume,
     sessionId: parsed['session-id'],
     forkSession: parsed['fork-session'] || false,
@@ -144,6 +146,8 @@ Options:
   --verbose                        Enable verbose mode
   --read-only                      Enforce native read-only mode (agent: --permission-mode readonly)
   --plan-only                      Enforce native planning mode (agent: --permission-mode plan)
+  --approve-each                   Approve each command (ask mode); relayable for: claude, agent
+  --permission-mode ask            Alias for --approve-each
   --resume <sessionId>             Resume a previous session by ID
   --session-id <uuid>              Use a specific session ID (must be valid UUID)
   --fork-session                   Create new session ID when resuming
@@ -174,6 +178,10 @@ Examples:
   # Read-only planning mode
   start-agent --tool claude --working-directory "/tmp/dir" \\
     --prompt "Inspect this project" --read-only
+
+  # Per-command approval (ask mode)
+  start-agent --tool agent --working-directory "/tmp/dir" \\
+    --prompt "Refactor this file" --approve-each
 
   # With screen isolation (detached)
   start-agent --tool claude --working-directory "/tmp/dir" \\

--- a/js/src/command-builder.mjs
+++ b/js/src/command-builder.mjs
@@ -3,6 +3,7 @@
  */
 
 import { isToolSupported, getTool } from './tools/index.mjs';
+import { askUnsupportedError } from './permissions/index.mjs';
 
 /**
  * Build the command for executing an agent
@@ -21,6 +22,7 @@ import { isToolSupported, getTool } from './tools/index.mjs';
  * @param {boolean} [options.detached] - Run in detached mode
  * @param {boolean} [options.readOnly] - Enforce native read-only/planning mode
  * @param {boolean} [options.planOnly] - Enforce native planning mode (where the tool distinguishes it)
+ * @param {boolean} [options.approveEach] - Enforce per-command approval (ask mode)
  * @returns {string} The command string
  */
 export function buildAgentCommand(options) {
@@ -39,6 +41,7 @@ export function buildAgentCommand(options) {
     detached = false,
     readOnly = false,
     planOnly = false,
+    approveEach = false,
     ...toolOptions
   } = options;
 
@@ -54,6 +57,9 @@ export function buildAgentCommand(options) {
     if (readOnlyRequested && !toolConfig.supportsReadOnly) {
       throw new Error(readOnlyUnsupportedError(tool));
     }
+    if (approveEach && !toolConfig.supportsAsk) {
+      throw new Error(askUnsupportedError({ tool }));
+    }
     if (toolConfig.buildCommand) {
       // Use tool-specific command builder
       baseCommand = toolConfig.buildCommand({
@@ -66,6 +72,7 @@ export function buildAgentCommand(options) {
         resume,
         readOnly: readOnlyRequested,
         planOnly,
+        approveEach,
         ...toolOptions,
       });
     } else {
@@ -80,6 +87,9 @@ export function buildAgentCommand(options) {
   } else {
     if (readOnlyRequested) {
       throw new Error(readOnlyUnsupportedError(tool));
+    }
+    if (approveEach) {
+      throw new Error(askUnsupportedError({ tool }));
     }
     // Unknown tool, use generic command builder
     baseCommand = buildToolCommand({

--- a/js/src/executor.mjs
+++ b/js/src/executor.mjs
@@ -48,10 +48,13 @@ export async function executeCommand(command, options = {}) {
  * @param {string} command - Command to execute
  * @param {Object} [options] - Execution options
  * @param {boolean} [options.attached] - If true, stream output to console
+ * @param {boolean} [options.pipeStdin] - If true, open the child's stdin as a
+ *   writable pipe (used by the per-command approval relay to send the prompt
+ *   and permission responses as NDJSON frames)
  * @returns {Promise<Object>} Process handle with methods to interact with the process
  */
 export async function startCommand(command, options = {}) {
-  const { attached = true, onStdout, onStderr } = options;
+  const { attached = true, onStdout, onStderr, pipeStdin = false } = options;
   const { spawn } = await import('node:child_process');
 
   let stdout = '';
@@ -65,7 +68,7 @@ export async function startCommand(command, options = {}) {
   });
 
   const child = spawn('bash', ['-c', command], {
-    stdio: ['ignore', 'pipe', 'pipe'],
+    stdio: [pipeStdin ? 'pipe' : 'ignore', 'pipe', 'pipe'],
   });
 
   child.stdout.on('data', (chunk) => {
@@ -118,6 +121,26 @@ export async function startCommand(command, options = {}) {
     waitForExit: () => exitPromise,
     getOutput: () => ({ stdout, stderr, exitCode, hasExited }),
     process: child,
+    /**
+     * Write a chunk to the child's stdin (no-op if stdin is not piped/open).
+     * @param {string} data - Data to write
+     * @returns {boolean} True when the write was attempted
+     */
+    writeStdin: (data) => {
+      if (child.stdin && child.stdin.writable) {
+        child.stdin.write(data);
+        return true;
+      }
+      return false;
+    },
+    /**
+     * Close the child's stdin (signals end-of-input).
+     */
+    endStdin: () => {
+      if (child.stdin && !child.stdin.destroyed) {
+        child.stdin.end();
+      }
+    },
   };
 }
 

--- a/js/src/index.mjs
+++ b/js/src/index.mjs
@@ -29,7 +29,7 @@ import { getTool, isToolSupported } from './tools/index.mjs';
 import { createOutputStream, createInputStream } from './streaming/index.mjs';
 import { stringifyNdjsonLine } from './streaming/ndjson.mjs';
 import { buildNormalizedResultMetadata } from './result-metadata.mjs';
-import { PermissionRelay } from './permissions/index.mjs';
+import { PermissionRelay, askUnsupportedError } from './permissions/index.mjs';
 
 const PROMPT_FILE_TOOLS = new Set([
   'claude',
@@ -295,6 +295,13 @@ export function agent(options) {
       onMessage,
       onOutput,
     } = startOptions;
+
+    // Fail clearly (before any filesystem side effects such as writing the
+    // temporary prompt file) when ask mode is requested for a tool that has no
+    // drivable per-command approval protocol — same pattern as `--read-only`.
+    if (approveEach && !(toolConfig && toolConfig.supportsAsk)) {
+      throw new Error(askUnsupportedError({ tool }));
+    }
 
     // Create output stream for JSON parsing if in JSON mode, callbacks are
     // provided, or a live permission relay is active (the relay inspects every

--- a/js/src/index.mjs
+++ b/js/src/index.mjs
@@ -27,7 +27,9 @@ import {
 } from './executor.mjs';
 import { getTool, isToolSupported } from './tools/index.mjs';
 import { createOutputStream, createInputStream } from './streaming/index.mjs';
+import { stringifyNdjsonLine } from './streaming/ndjson.mjs';
 import { buildNormalizedResultMetadata } from './result-metadata.mjs';
+import { PermissionRelay } from './permissions/index.mjs';
 
 const PROMPT_FILE_TOOLS = new Set([
   'claude',
@@ -63,6 +65,34 @@ function buildPromptFileContent(options) {
   }
 
   return systemPrompt ? `${systemPrompt}\n\n${prompt || ''}` : prompt || '';
+}
+
+/**
+ * Build the initial user-message frame written to a tool's stdin when relaying
+ * per-command approvals over a streaming input channel.
+ * @param {Object} options - Options
+ * @param {string} options.toolName - Tool name (`agent` | `claude`)
+ * @param {string} [options.prompt] - User prompt
+ * @param {string} [options.systemPrompt] - System prompt
+ * @returns {Object} A user-message frame ready to be serialized as NDJSON
+ */
+function buildInitialInputFrame(options) {
+  const { toolName, prompt, systemPrompt } = options;
+
+  if (toolName === 'claude') {
+    // Claude stream-json input expects an Anthropic-style message envelope.
+    return {
+      type: 'user',
+      message: { role: 'user', content: prompt || '' },
+    };
+  }
+
+  // Agent's stream-json input takes a plain user message string (system prompt
+  // is combined in, since agent has no separate system-prompt channel here).
+  const combinedPrompt = systemPrompt
+    ? `${systemPrompt}\n\n${prompt || ''}`
+    : prompt || '';
+  return { type: 'user', message: combinedPrompt };
 }
 
 /**
@@ -151,6 +181,10 @@ function parseJsonMessages(options) {
  * @param {string} [options.resume] - Resume a previous session (tool-specific)
  * @param {boolean} [options.readOnly=false] - Enforce native read-only/planning mode
  * @param {boolean} [options.planOnly=false] - Enforce native planning mode (where the tool distinguishes it)
+ * @param {boolean} [options.approveEach=false] - Enforce per-command approval (ask mode)
+ * @param {Function} [options.onPermissionRequest] - async (normalizedRequest) => 'once'|'always'|'reject';
+ *   when provided together with approveEach for a relay-capable tool, native permission requests are
+ *   normalized, relayed to this callback, and the decision is forwarded to the tool's stdin
  * @param {Object} [options.toolOptions] - Additional tool-specific options
  * @returns {Object} Agent controller with start, stop, and utility methods
  */
@@ -169,6 +203,8 @@ export function agent(options) {
     resume,
     readOnly = false,
     planOnly = false,
+    approveEach = false,
+    onPermissionRequest,
     toolOptions = {},
   } = options;
 
@@ -191,10 +227,20 @@ export function agent(options) {
     ? getTool({ toolName: tool })
     : null;
 
+  // Live per-command approval relay is active only when ask mode is requested,
+  // a decision callback is supplied, and the tool exposes a relayable protocol.
+  const relayActive = Boolean(
+    approveEach &&
+    typeof onPermissionRequest === 'function' &&
+    toolConfig &&
+    toolConfig.supportsAsk
+  );
+
   let processHandle = null;
   let removeSignalHandler = null;
   let command = null;
   let outputStream = null;
+  let permissionRelay = null;
   let sessionId = null;
   let promptTempDir = null;
 
@@ -250,15 +296,32 @@ export function agent(options) {
       onOutput,
     } = startOptions;
 
-    // Create output stream for JSON parsing if in JSON mode or callbacks provided
-    if (json || onMessage) {
+    // Create output stream for JSON parsing if in JSON mode, callbacks are
+    // provided, or a live permission relay is active (the relay inspects every
+    // parsed message looking for native permission requests).
+    if (json || onMessage || relayActive) {
       outputStream = createOutputStream({
-        onMessage: onMessage ? (data) => onMessage(data.message) : undefined,
+        onMessage: (data) => {
+          if (onMessage) {
+            onMessage(data.message);
+          }
+          if (permissionRelay) {
+            // Relay native permission requests to the consumer and forward the
+            // decision to the tool's stdin. Errors must not break the stream.
+            Promise.resolve(
+              permissionRelay.handleMessage({ message: data.message })
+            ).catch(() => {});
+          }
+        },
       });
     }
 
     try {
-      const preparedPromptFile = await preparePromptFile({ dryRun });
+      // In relay mode the prompt is delivered as the initial NDJSON user frame
+      // over stdin, so no temporary prompt file is created or piped.
+      const preparedPromptFile = relayActive
+        ? undefined
+        : await preparePromptFile({ dryRun });
       const promptHandledByTempFile = preparedPromptFile && !promptFile;
 
       // Build the command with tool-specific options
@@ -277,6 +340,7 @@ export function agent(options) {
         detached,
         readOnly,
         planOnly,
+        approveEach,
       };
 
       // Add tool-specific options if tool is known
@@ -285,6 +349,15 @@ export function agent(options) {
         commandOptions.json = json;
         commandOptions.resume = resume;
         Object.assign(commandOptions, toolOptions);
+      }
+
+      // When relaying per-command approvals, force a streaming JSON channel in
+      // both directions: the tool emits permission requests on stdout and reads
+      // our decisions plus the initial prompt as NDJSON frames on stdin.
+      if (relayActive) {
+        commandOptions.json = true;
+        commandOptions.jsonInput = true;
+        commandOptions.streamInput = true;
       }
 
       command = buildAgentCommand(commandOptions);
@@ -314,7 +387,7 @@ export function agent(options) {
         }
       } else {
         // For attached mode, start command without waiting
-        const commandOptions = { attached };
+        const commandOptions = { attached, pipeStdin: relayActive };
 
         // Add output handling for streaming
         if (onOutput) {
@@ -334,6 +407,27 @@ export function agent(options) {
         }
 
         processHandle = await startCommand(command, commandOptions);
+
+        // Establish the live permission relay: it writes normalized decisions
+        // (and the initial user prompt) to the child's stdin as NDJSON frames.
+        if (relayActive) {
+          permissionRelay = new PermissionRelay({
+            tool,
+            onRequest: onPermissionRequest,
+            write: (line) => processHandle.writeStdin(line),
+          });
+
+          // Kick off the turn by sending the user prompt as the first frame.
+          processHandle.writeStdin(
+            stringifyNdjsonLine({
+              value: buildInitialInputFrame({
+                toolName: tool,
+                prompt,
+                systemPrompt,
+              }),
+            })
+          );
+        }
       }
     } catch (error) {
       await cleanupPromptTempDir();
@@ -553,3 +647,15 @@ export { tools, getTool, listTools, isToolSupported } from './tools/index.mjs';
 export { JsonOutputStream, JsonInputStream } from './streaming/index.mjs';
 export { parseNdjsonLine, stringifyNdjsonLine } from './streaming/ndjson.mjs';
 export { buildNormalizedResultMetadata } from './result-metadata.mjs';
+export {
+  ASK_SUPPORTED_TOOLS,
+  ASK_DECISIONS,
+  ASK_SCOPE,
+  PERMISSION_PARITY,
+  supportsAsk,
+  askUnsupportedError,
+  normalizePermissionRequest,
+  buildPermissionResponse,
+  PermissionRelay,
+  createPermissionRelay,
+} from './permissions/index.mjs';

--- a/js/src/permissions/index.mjs
+++ b/js/src/permissions/index.mjs
@@ -1,0 +1,19 @@
+/**
+ * Uniform per-command approval ("ask" mode) permission relay.
+ *
+ * Public surface for normalizing native permission requests, building native
+ * responses, relaying decisions, and inspecting per-tool parity.
+ */
+
+export {
+  ASK_SUPPORTED_TOOLS,
+  ASK_DECISIONS,
+  ASK_SCOPE,
+  PERMISSION_PARITY,
+  supportsAsk,
+  askUnsupportedError,
+  normalizePermissionRequest,
+  buildPermissionResponse,
+} from './normalize.mjs';
+
+export { PermissionRelay, createPermissionRelay } from './relay.mjs';

--- a/js/src/permissions/normalize.mjs
+++ b/js/src/permissions/normalize.mjs
@@ -1,0 +1,293 @@
+/**
+ * Permission normalization for the uniform per-command approval ("ask") mode.
+ *
+ * Each backend CLI that supports interactive, per-command approval exposes the
+ * approval handshake over a different JSON wire format. This module translates
+ * those native frames into a single normalized `permission_request` event and
+ * translates a normalized decision (`once` | `always` | `reject`) back into the
+ * native response frame that the CLI expects on its stdin.
+ *
+ * Only tools with a *drivable* JSON request/response permission protocol can be
+ * relayed (see {@link ASK_SUPPORTED_TOOLS}). Tools whose only native approval
+ * mechanism is a static policy (`opencode`), a sandbox coupling (`codex`), or a
+ * non-streaming approval flag (`qwen`, `gemini`) are documented in the parity
+ * table but fail clearly when ask mode is requested — mirroring the
+ * `--read-only` unsupported-tool pattern.
+ */
+
+/**
+ * Tools that expose a relayable per-command approval protocol over JSON.
+ * @type {Set<string>}
+ */
+export const ASK_SUPPORTED_TOOLS = new Set(['agent', 'claude']);
+
+/**
+ * Normalized decisions a consumer may return for a permission request.
+ * @type {Set<string>}
+ */
+export const ASK_DECISIONS = new Set(['once', 'always', 'reject']);
+
+/**
+ * Scope of an `always` decision for each backend. The reviewer (m13v) flagged
+ * that "always" does not mean the same thing across CLIs, so the normalized
+ * event and the parity table both carry this scope.
+ *
+ * - `session`  — `always` auto-approves later matching requests for the rest of
+ *                the session (agent's native `always`).
+ * - `tool-input` — approval binds to the tool name + input shape; Claude has no
+ *                native session-wide `always`, so `once` and `always` both map
+ *                to a single allow decision bound to that tool call's input.
+ * @type {Record<string, string>}
+ */
+export const ASK_SCOPE = {
+  agent: 'session',
+  claude: 'tool-input',
+};
+
+/**
+ * Whether agent-commander can relay per-command approvals for the given tool.
+ * @param {Object} options - Options
+ * @param {string} options.tool - Tool name
+ * @returns {boolean} True when the tool has a relayable approval protocol
+ */
+export function supportsAsk(options) {
+  const { tool } = options;
+  return ASK_SUPPORTED_TOOLS.has(tool);
+}
+
+/**
+ * Build the standard error for tools without a relayable per-command approval
+ * mechanism (ask mode). Mirrors `readOnlyUnsupportedError`.
+ * @param {Object} options - Options
+ * @param {string} options.tool - Tool name
+ * @returns {string} Error message
+ */
+export function askUnsupportedError(options) {
+  const { tool } = options;
+  const supported = [...ASK_SUPPORTED_TOOLS].join(', ');
+  return `Tool "${tool}" does not support enforceable per-command approval (ask mode). Choose one of: ${supported}; or run without --approve-each.`;
+}
+
+/**
+ * Derive a human-readable command string from a Claude tool input payload.
+ * @param {Object} options - Options
+ * @param {string} [options.toolName] - Claude tool name (e.g. `Bash`, `Edit`)
+ * @param {Object} [options.input] - Tool input payload
+ * @returns {string|null} A best-effort command/target string or null
+ */
+function deriveClaudeCommand(options) {
+  const { toolName, input } = options;
+  if (!input || typeof input !== 'object') {
+    return null;
+  }
+  // Bash carries the literal shell command.
+  if (typeof input.command === 'string') {
+    return input.command;
+  }
+  // File tools carry the target path.
+  if (typeof input.file_path === 'string') {
+    return input.file_path;
+  }
+  if (typeof input.path === 'string') {
+    return input.path;
+  }
+  // WebFetch / WebSearch carry a URL or query.
+  if (typeof input.url === 'string') {
+    return input.url;
+  }
+  return toolName || null;
+}
+
+/**
+ * Normalize a native permission request frame into a uniform event.
+ *
+ * Returns `null` when the message is not a permission request for the tool, so
+ * callers can pass every parsed output message through unconditionally.
+ *
+ * @param {Object} options - Options
+ * @param {string} options.tool - Tool name (`agent` | `claude`)
+ * @param {Object} options.message - A parsed output message from the tool
+ * @returns {Object|null} Normalized permission_request event or null
+ */
+export function normalizePermissionRequest(options) {
+  const { tool, message } = options;
+  if (!message || typeof message !== 'object') {
+    return null;
+  }
+
+  if (tool === 'agent') {
+    if (message.type !== 'permission_request') {
+      return null;
+    }
+    const id = message.permissionID ?? message.permission_id ?? null;
+    const metadata =
+      message.metadata && typeof message.metadata === 'object'
+        ? message.metadata
+        : {};
+    return {
+      type: 'permission_request',
+      tool: 'agent',
+      id,
+      sessionId: message.sessionID ?? message.session_id ?? null,
+      callId: message.callID ?? message.call_id ?? null,
+      toolName: message.tool ?? null,
+      title: message.title ?? null,
+      command: metadata.command ?? message.title ?? null,
+      pattern: message.pattern ?? metadata.patterns ?? null,
+      scope: ASK_SCOPE.agent,
+      input: null,
+      raw: message,
+    };
+  }
+
+  if (tool === 'claude') {
+    if (
+      message.type !== 'control_request' ||
+      !message.request ||
+      message.request.subtype !== 'can_use_tool'
+    ) {
+      return null;
+    }
+    const request = message.request;
+    const toolName = request.tool_name ?? null;
+    const input =
+      request.input && typeof request.input === 'object' ? request.input : null;
+    return {
+      type: 'permission_request',
+      tool: 'claude',
+      id: message.request_id ?? null,
+      sessionId: message.session_id ?? null,
+      callId: request.tool_use_id ?? null,
+      toolName,
+      title: toolName,
+      command: deriveClaudeCommand({ toolName, input }),
+      pattern: null,
+      scope: ASK_SCOPE.claude,
+      input,
+      raw: message,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Build the native response frame for a normalized decision.
+ *
+ * @param {Object} options - Options
+ * @param {string} options.tool - Tool name (`agent` | `claude`)
+ * @param {Object} options.request - The normalized request being answered
+ * @param {string} options.decision - `once` | `always` | `reject`
+ * @returns {Object} Native response frame ready to be serialized to stdin
+ */
+export function buildPermissionResponse(options) {
+  const { tool, request, decision } = options;
+
+  if (!ASK_DECISIONS.has(decision)) {
+    throw new Error(
+      `Invalid permission decision "${decision}". Expected one of: once, always, reject.`
+    );
+  }
+  if (!request || typeof request !== 'object') {
+    throw new Error('A normalized permission request is required.');
+  }
+
+  if (tool === 'agent') {
+    // Agent's native protocol accepts once | always | reject verbatim.
+    return {
+      type: 'permission_response',
+      permissionID: request.id,
+      response: decision,
+    };
+  }
+
+  if (tool === 'claude') {
+    // Claude's stream-json control protocol expects an allow/deny behavior.
+    // It has no native session-wide "always", so once and always both map to a
+    // single allow bound to this tool call's input (scope: tool-input).
+    if (decision === 'reject') {
+      return {
+        type: 'control_response',
+        response: {
+          subtype: 'success',
+          request_id: request.id,
+          response: {
+            behavior: 'deny',
+            message: 'Denied by consumer (ask mode).',
+          },
+        },
+      };
+    }
+    return {
+      type: 'control_response',
+      response: {
+        subtype: 'success',
+        request_id: request.id,
+        response: {
+          behavior: 'allow',
+          updatedInput: request.input ?? {},
+        },
+      },
+    };
+  }
+
+  throw new Error(askUnsupportedError({ tool }));
+}
+
+/**
+ * Parity description for each tool's native per-command approval mechanism.
+ * Surfaced in the docs parity table; `scope` documents what an `always`/allow
+ * decision attaches to, and `relay` indicates whether agent-commander can drive
+ * the handshake as normalized JSON.
+ * @type {Array<Object>}
+ */
+export const PERMISSION_PARITY = [
+  {
+    tool: 'agent',
+    nativeMechanism: '--permission-mode ask (+ --input-format stream-json)',
+    scope: 'session',
+    relay: true,
+    notes:
+      'Native JSON permission_request/permission_response protocol; once | always | reject map 1:1.',
+  },
+  {
+    tool: 'claude',
+    nativeMechanism: '--permission-mode default (stream-json can_use_tool)',
+    scope: 'tool-input',
+    relay: true,
+    notes:
+      'control_request/control_response handshake; no session-wide always, so once and always both allow this call.',
+  },
+  {
+    tool: 'codex',
+    nativeMechanism: '--ask-for-approval (coupled with --sandbox)',
+    scope: 'sandbox-coupled',
+    relay: false,
+    notes:
+      'Approval is coupled with the sandbox policy and not exposed as a tool-agnostic JSON request/response stream.',
+  },
+  {
+    tool: 'qwen',
+    nativeMechanism: '--approval-mode default',
+    scope: 'interactive-only',
+    relay: false,
+    notes:
+      'Headless mode has no relayable per-command JSON approval handshake.',
+  },
+  {
+    tool: 'gemini',
+    nativeMechanism: '--approval-mode default',
+    scope: 'interactive-only',
+    relay: false,
+    notes:
+      'No JSON stdin channel (prompt is passed via -p), so approvals cannot be relayed.',
+  },
+  {
+    tool: 'opencode',
+    nativeMechanism: 'OPENCODE_PERMISSION (static {edit,bash,task} policy)',
+    scope: 'static-policy',
+    relay: false,
+    notes:
+      'Only a static up-front policy is available; there is no per-command request/response relay.',
+  },
+];

--- a/js/src/permissions/relay.mjs
+++ b/js/src/permissions/relay.mjs
@@ -1,0 +1,101 @@
+/**
+ * Permission relay for the uniform per-command approval ("ask") mode.
+ *
+ * A {@link PermissionRelay} sits between a backend CLI's streaming output and a
+ * consumer: it watches parsed output messages for native permission requests,
+ * normalizes them, asks the consumer for a decision, and writes the native
+ * response frame back to the CLI's stdin as NDJSON.
+ *
+ * The relay is intentionally transport-agnostic — it does not own the child
+ * process. The caller supplies a `write` function (typically the child's stdin)
+ * and feeds it parsed messages, which keeps it fully unit-testable.
+ */
+
+import { stringifyNdjsonLine } from '../streaming/ndjson.mjs';
+import {
+  normalizePermissionRequest,
+  buildPermissionResponse,
+  ASK_DECISIONS,
+} from './normalize.mjs';
+
+/**
+ * Relay native permission requests to a consumer and forward decisions back.
+ */
+export class PermissionRelay {
+  /**
+   * @param {Object} options - Options
+   * @param {string} options.tool - Tool name (`agent` | `claude`)
+   * @param {Function} options.onRequest - async (normalizedRequest) => decision
+   *   where decision is `once` | `always` | `reject`
+   * @param {Function} options.write - (line: string) => void; writes a serialized
+   *   NDJSON frame to the tool's stdin
+   * @param {boolean} [options.compact=true] - Use compact NDJSON
+   */
+  constructor(options) {
+    const { tool, onRequest, write, compact = true } = options;
+    if (!tool) {
+      throw new Error('tool is required');
+    }
+    if (typeof onRequest !== 'function') {
+      throw new Error('onRequest callback is required');
+    }
+    if (typeof write !== 'function') {
+      throw new Error('write callback is required');
+    }
+    this.tool = tool;
+    this.onRequest = onRequest;
+    this.write = write;
+    this.compact = compact;
+    this.handled = [];
+  }
+
+  /**
+   * Process a single parsed output message. When the message is a permission
+   * request, resolves the consumer's decision and writes the native response.
+   * @param {Object} options - Options
+   * @param {Object} options.message - A parsed output message from the tool
+   * @returns {Promise<Object|null>} { request, decision, frame } or null when the
+   *   message is not a permission request
+   */
+  async handleMessage(options) {
+    const { message } = options;
+    const request = normalizePermissionRequest({ tool: this.tool, message });
+    if (!request) {
+      return null;
+    }
+
+    let decision = await this.onRequest(request);
+    // Default to the safe choice if the consumer returns nothing usable.
+    if (!ASK_DECISIONS.has(decision)) {
+      decision = 'reject';
+    }
+
+    const frame = buildPermissionResponse({
+      tool: this.tool,
+      request,
+      decision,
+    });
+    this.write(stringifyNdjsonLine({ value: frame, compact: this.compact }));
+
+    const record = { request, decision, frame };
+    this.handled.push(record);
+    return record;
+  }
+
+  /**
+   * All permission requests handled so far (for inspection/testing).
+   * @returns {Array<Object>} Handled { request, decision, frame } records
+   */
+  getHandled() {
+    return this.handled;
+  }
+}
+
+/**
+ * Convenience factory for a {@link PermissionRelay}.
+ * @param {Object} options - See {@link PermissionRelay} constructor
+ * @returns {PermissionRelay} A new relay
+ */
+export function createPermissionRelay(options) {
+  return new PermissionRelay(options);
+}

--- a/js/src/tools/agent.mjs
+++ b/js/src/tools/agent.mjs
@@ -72,6 +72,7 @@ export function mapModelToId(options) {
  * @param {boolean} [options.useExistingClaudeOAuth] - Use existing Claude OAuth credentials
  * @param {boolean} [options.readOnly] - Enforce hard read-only mode (`--permission-mode readonly`)
  * @param {boolean} [options.planOnly] - Enforce planning mode (`--permission-mode plan`)
+ * @param {boolean} [options.approveEach] - Approve each mutating command (`--permission-mode ask`)
  * @param {string} [options.permissionMode] - Explicit agent permission mode (auto | plan | readonly | ask)
  * @param {string} [options.permission] - OpenCode-compatible `--permission` JSON policy
  * @param {string[]} [options.extraArgs] - Extra raw CLI args appended after typed args
@@ -84,6 +85,7 @@ export function buildArgs(options) {
     useExistingClaudeOAuth = false,
     readOnly = false,
     planOnly = false,
+    approveEach = false,
     permissionMode,
     permission,
     extraArgs = [],
@@ -93,11 +95,26 @@ export function buildArgs(options) {
 
   // Native, enforceable permission system (agent v0.24.0, PR #272).
   // --plan-only maps to `plan`, --read-only maps to the harder `readonly`,
-  // matching agent's own distinction between the two modes.
+  // --approve-each maps to `ask` (per-command approval relayed over JSON),
+  // matching agent's own distinction between the modes. An explicit
+  // permissionMode always wins.
   const resolvedPermissionMode =
-    permissionMode || (planOnly ? 'plan' : readOnly ? 'readonly' : undefined);
+    permissionMode ||
+    (approveEach
+      ? 'ask'
+      : planOnly
+        ? 'plan'
+        : readOnly
+          ? 'readonly'
+          : undefined);
   if (resolvedPermissionMode) {
     args.push('--permission-mode', resolvedPermissionMode);
+  }
+
+  // Ask mode emits requests mid-turn and blocks until answered, so it requires
+  // a streaming input mode (single-shot --prompt would deadlock).
+  if (resolvedPermissionMode === 'ask') {
+    args.push('--input-format', 'stream-json');
   }
 
   if (permission) {
@@ -135,6 +152,7 @@ export function buildArgs(options) {
  * @param {boolean} [options.useExistingClaudeOAuth] - Use existing Claude OAuth
  * @param {boolean} [options.readOnly] - Enforce hard read-only mode (`--permission-mode readonly`)
  * @param {boolean} [options.planOnly] - Enforce planning mode (`--permission-mode plan`)
+ * @param {boolean} [options.approveEach] - Approve each mutating command (`--permission-mode ask`)
  * @param {string} [options.permissionMode] - Explicit agent permission mode (auto | plan | readonly | ask)
  * @param {string} [options.permission] - OpenCode-compatible `--permission` JSON policy
  * @param {string} [options.executable='agent'] - Executable path/name
@@ -149,9 +167,22 @@ export function buildCommand(options) {
     systemPrompt,
     executable = 'agent',
     extraEnv,
+    streamInput = false,
     ...argOptions
   } = options;
   const args = buildArgs(argOptions);
+
+  const commandHead = `${buildCommandHead({
+    executable,
+    extraEnv,
+  })} ${args.map(escapeArg).join(' ')}`.trim();
+
+  // In stream-input mode the caller owns the child's stdin and writes the
+  // prompt and permission responses as NDJSON frames (per-command approval
+  // relay), so no prompt is piped here.
+  if (streamInput) {
+    return commandHead;
+  }
 
   // Agent expects prompt via stdin, combine system and user prompts
   const combinedPrompt = systemPrompt
@@ -162,10 +193,7 @@ export function buildCommand(options) {
   const inputCommand = promptFile
     ? `cat ${escapeArg(promptFile)}`
     : `printf '%s' '${combinedPrompt.replace(/'/g, "'\\''")}'`;
-  return `${inputCommand} | ${buildCommandHead({
-    executable,
-    extraEnv,
-  })} ${args.map(escapeArg).join(' ')}`.trim();
+  return `${inputCommand} | ${commandHead}`.trim();
 }
 
 /**
@@ -310,6 +338,7 @@ export const agentTool = {
   supportsSystemPrompt: false, // System prompt is combined with user prompt
   supportsResume: false, // Agent doesn't have explicit resume like Claude
   supportsReadOnly: true, // Native --permission-mode readonly/plan (agent v0.24.0, PR #272)
+  supportsAsk: true, // Native --permission-mode ask with JSON permission relay
   defaultModel: 'nemotron-3-super-free', // hive-mind issue #1563, agent PR #243
   modelMap,
   mapModelToId,

--- a/js/src/tools/claude.mjs
+++ b/js/src/tools/claude.mjs
@@ -60,6 +60,7 @@ export function mapModelToId(options) {
  * @param {string} [options.sessionId] - Use specific session ID (must be valid UUID)
  * @param {boolean} [options.forkSession] - Create new session ID when resuming
  * @param {boolean} [options.readOnly] - Use Claude plan permission mode
+ * @param {boolean} [options.approveEach] - Approve each command (`--permission-mode default`)
  * @param {string[]} [options.extraArgs] - Extra raw CLI args appended after typed args
  * @param {boolean} [options.skipDefaultSafetyFlags] - Do not add default bypass flags
  * @param {string} [options.permissionMode] - Explicit Claude permission mode
@@ -81,6 +82,7 @@ export function buildArgs(options) {
     sessionId,
     forkSession = false,
     readOnly = false,
+    approveEach = false,
     extraArgs = [],
     skipDefaultSafetyFlags = false,
     permissionMode,
@@ -88,7 +90,12 @@ export function buildArgs(options) {
 
   const args = [];
 
-  if (readOnly) {
+  if (approveEach) {
+    // Per-command approval: ask before each tool use via the stream-json
+    // can_use_tool control protocol. `default` keeps Claude's own prompting
+    // active instead of bypassing it; the relay answers each request.
+    args.push('--permission-mode', 'default');
+  } else if (readOnly) {
     args.push('--permission-mode', 'plan');
   } else if (permissionMode) {
     args.push('--permission-mode', permissionMode);
@@ -179,6 +186,7 @@ export function buildArgs(options) {
  * @param {string} [options.sessionId] - Use specific session ID (must be valid UUID)
  * @param {boolean} [options.forkSession] - Create new session ID when resuming
  * @param {boolean} [options.readOnly] - Use Claude plan permission mode
+ * @param {boolean} [options.approveEach] - Approve each command (`--permission-mode default`)
  * @param {string} [options.executable='claude'] - Executable path/name
  * @param {Object|Array} [options.extraEnv] - Environment variables for the tool
  * @param {string[]} [options.extraArgs] - Extra raw CLI args appended after typed args
@@ -192,14 +200,21 @@ export function buildCommand(options) {
     promptFile,
     executable = 'claude',
     extraEnv,
+    streamInput = false,
     ...argOptions
   } = options;
   const args = buildArgs({
     ...argOptions,
-    prompt: promptFile ? undefined : prompt,
+    // In stream-input mode the prompt is written to stdin as NDJSON frames by
+    // the per-command approval relay, so it is not passed as a --prompt arg.
+    prompt: promptFile || streamInput ? undefined : prompt,
   });
   const command =
     `${buildCommandHead({ executable, extraEnv })} ${args.map(escapeArg).join(' ')}`.trim();
+
+  if (streamInput) {
+    return command;
+  }
 
   if (promptFile) {
     return `cat ${escapeArg(promptFile)} | ${command}`;
@@ -312,6 +327,7 @@ export const claudeTool = {
   supportsVerbose: true, // Supports --verbose
   supportsReplayUserMessages: true, // Supports --replay-user-messages
   supportsReadOnly: true, // Supports --permission-mode plan
+  supportsAsk: true, // Per-command approval via stream-json can_use_tool relay
   defaultModel: 'sonnet',
   modelMap,
   mapModelToId,

--- a/js/src/tools/codex.mjs
+++ b/js/src/tools/codex.mjs
@@ -258,6 +258,7 @@ export const codexTool = {
   supportsSystemPrompt: false, // System prompt is combined with user prompt
   supportsResume: true,
   supportsReadOnly: true, // Supports --sandbox read-only
+  supportsAsk: false, // --ask-for-approval is coupled with the sandbox; not a relayable JSON handshake
   defaultModel: 'gpt-5.5', // hive-mind PR #1657
   modelMap,
   mapModelToId,

--- a/js/src/tools/gemini.mjs
+++ b/js/src/tools/gemini.mjs
@@ -329,6 +329,7 @@ export const geminiTool = {
   supportsCheckpointing: true, // Supports --checkpointing
   supportsDebug: true, // Supports -d for debug output
   supportsReadOnly: true, // Supports --approval-mode plan
+  supportsAsk: false, // No JSON stdin channel (prompt via -p), so approvals cannot be relayed
   defaultModel: 'gemini-2.5-flash',
   modelMap,
   mapModelToId,

--- a/js/src/tools/opencode.mjs
+++ b/js/src/tools/opencode.mjs
@@ -214,6 +214,7 @@ export const opencodeTool = {
   supportsSystemPrompt: false, // System prompt is combined with user prompt
   supportsResume: true,
   supportsReadOnly: true, // Supports OPENCODE_PERMISSION
+  supportsAsk: false, // Only a static up-front policy; no per-command request/response relay
   defaultModel: 'grok-code-fast-1',
   modelMap,
   mapModelToId,

--- a/js/src/tools/qwen.mjs
+++ b/js/src/tools/qwen.mjs
@@ -325,6 +325,7 @@ export const qwenTool = {
   supportsIncludeDirectories: true, // Supports --include-directories
   supportsIncludePartialMessages: true, // Supports --include-partial-messages
   supportsReadOnly: true, // Supports --approval-mode plan
+  supportsAsk: false, // No relayable per-command JSON approval handshake in headless mode
   defaultModel: 'qwen3-coder-480a35',
   modelMap,
   mapModelToId,

--- a/js/test/cli-parser.test.mjs
+++ b/js/test/cli-parser.test.mjs
@@ -274,6 +274,40 @@ test('parseStartAgentArgs - plan-only aliases read-only', () => {
   assert.strictEqual(result.readOnly, true);
 });
 
+test('parseStartAgentArgs - with approve-each flag', () => {
+  const args = [
+    '--tool',
+    'agent',
+    '--working-directory',
+    '/tmp/test',
+    '--approve-each',
+  ];
+  const result = parseStartAgentArgs(args);
+
+  assert.strictEqual(result.approveEach, true);
+});
+
+test('parseStartAgentArgs - permission-mode ask aliases approve-each', () => {
+  const args = [
+    '--tool',
+    'agent',
+    '--working-directory',
+    '/tmp/test',
+    '--permission-mode',
+    'ask',
+  ];
+  const result = parseStartAgentArgs(args);
+
+  assert.strictEqual(result.approveEach, true);
+});
+
+test('parseStartAgentArgs - approve-each defaults to false', () => {
+  const args = ['--tool', 'agent', '--working-directory', '/tmp/test'];
+  const result = parseStartAgentArgs(args);
+
+  assert.strictEqual(result.approveEach, false);
+});
+
 test('parseStartAgentArgs - defaults for new options', () => {
   const args = ['--tool', 'claude', '--working-directory', '/tmp/test'];
   const result = parseStartAgentArgs(args);

--- a/js/test/command-builder.test.mjs
+++ b/js/test/command-builder.test.mjs
@@ -404,6 +404,64 @@ test('buildAgentCommand - read-only rejects unsupported tool', () => {
   }, /does not support enforceable read-only mode/);
 });
 
+test('buildAgentCommand - agent approve-each uses ask permission mode and stream-json', () => {
+  const command = buildAgentCommand({
+    tool: 'agent',
+    workingDirectory: '/tmp/test',
+    prompt: 'Refactor this file',
+    approveEach: true,
+    streamInput: true,
+    isolation: 'none',
+  });
+
+  assert.ok(command.includes('--permission-mode'));
+  assert.ok(command.includes('ask'));
+  assert.ok(command.includes('--input-format'));
+  assert.ok(command.includes('stream-json'));
+  // In stream-input mode the prompt is not piped via printf.
+  assert.ok(!command.includes('printf'));
+});
+
+test('buildAgentCommand - claude approve-each keeps default permission mode', () => {
+  const command = buildAgentCommand({
+    tool: 'claude',
+    workingDirectory: '/tmp/test',
+    prompt: 'Refactor this file',
+    approveEach: true,
+    streamInput: true,
+    isolation: 'none',
+  });
+
+  assert.ok(command.includes('--permission-mode'));
+  assert.ok(command.includes('default'));
+  // Must not bypass permissions when relaying per-command approvals.
+  assert.ok(!command.includes('--dangerously-skip-permissions'));
+});
+
+test('buildAgentCommand - approve-each rejects unsupported known tool (codex)', () => {
+  assert.throws(() => {
+    buildAgentCommand({
+      tool: 'codex',
+      workingDirectory: '/tmp/test',
+      prompt: 'Hello',
+      approveEach: true,
+      isolation: 'none',
+    });
+  }, /does not support enforceable per-command approval/);
+});
+
+test('buildAgentCommand - approve-each rejects unsupported unknown tool', () => {
+  assert.throws(() => {
+    buildAgentCommand({
+      tool: 'unknown-tool',
+      workingDirectory: '/tmp/test',
+      prompt: 'Hello',
+      approveEach: true,
+      isolation: 'none',
+    });
+  }, /does not support enforceable per-command approval/);
+});
+
 test('buildScreenStopCommand', () => {
   const command = buildScreenStopCommand('my-session');
   assert.ok(command.includes('screen'));

--- a/js/test/index.test.mjs
+++ b/js/test/index.test.mjs
@@ -221,3 +221,85 @@ printf '%s\\n' '{"type":"result","subtype":"success","session_id":"claude-sessio
     assert.strictEqual(result.metadata.errorDuringExecution, false);
   }
 );
+
+test(
+  'agent - approve-each relays native permission requests end-to-end',
+  { skip: process.platform === 'win32' || isDeno },
+  async (t) => {
+    // A fake `agent` binary that emits one native permission_request frame on
+    // stdout and waits for the relay to write a permission_response on its
+    // stdin, then echoes that response back so the test can verify the round
+    // trip without a real CLI.
+    const binDir = await mkdtemp(join(tmpdir(), 'agent-commander-test-bin-'));
+    const fakeAgent = join(binDir, 'agent');
+    await writeFile(
+      fakeAgent,
+      `#!/usr/bin/env bash
+printf '%s\\n' '{"type":"permission_request","permissionID":"p1","tool":"bash","title":"Run command","metadata":{"command":"rm -rf build"}}'
+while IFS= read -r line; do
+  case "$line" in
+    *permission_response*)
+      printf 'RELAYED %s\\n' "$line"
+      exit 0
+      ;;
+  esac
+done
+exit 0
+`
+    );
+    await chmod(fakeAgent, 0o755);
+
+    const previousPath = process.env.PATH || '';
+    process.env.PATH = `${binDir}:${previousPath}`;
+    t.after(async () => {
+      process.env.PATH = previousPath;
+      await rm(binDir, { recursive: true, force: true });
+    });
+
+    const seen = [];
+    const controller = agent({
+      tool: 'agent',
+      workingDirectory: '/tmp',
+      prompt: 'Refactor this file',
+      approveEach: true,
+      onPermissionRequest: (request) => {
+        seen.push(request);
+        return 'reject';
+      },
+    });
+
+    await controller.start({ attached: false });
+    const result = await controller.stop();
+
+    assert.strictEqual(result.exitCode, 0);
+
+    // The normalized request was relayed to the consumer.
+    assert.strictEqual(seen.length, 1);
+    assert.strictEqual(seen[0].type, 'permission_request');
+    assert.strictEqual(seen[0].tool, 'agent');
+    assert.strictEqual(seen[0].id, 'p1');
+    assert.strictEqual(seen[0].command, 'rm -rf build');
+    assert.strictEqual(seen[0].scope, 'session');
+
+    // The native response frame was written to the tool's stdin (the fake tool
+    // echoes it back prefixed with RELAYED).
+    assert.ok(result.output.plain.includes('RELAYED'));
+    assert.ok(result.output.plain.includes('"permissionID":"p1"'));
+    assert.ok(result.output.plain.includes('"response":"reject"'));
+  }
+);
+
+test('agent - approve-each on unsupported tool throws at start', async () => {
+  const controller = agent({
+    tool: 'codex',
+    workingDirectory: '/tmp',
+    prompt: 'Hello',
+    approveEach: true,
+    onPermissionRequest: () => 'once',
+  });
+
+  await assert.rejects(
+    () => controller.start({ attached: false }),
+    /does not support enforceable per-command approval/
+  );
+});

--- a/js/test/permissions.test.mjs
+++ b/js/test/permissions.test.mjs
@@ -1,0 +1,341 @@
+/**
+ * Tests for the uniform per-command approval ("ask" mode) permission relay.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert';
+import {
+  ASK_SUPPORTED_TOOLS,
+  ASK_DECISIONS,
+  ASK_SCOPE,
+  PERMISSION_PARITY,
+  supportsAsk,
+  askUnsupportedError,
+  normalizePermissionRequest,
+  buildPermissionResponse,
+  PermissionRelay,
+  createPermissionRelay,
+} from '../src/permissions/index.mjs';
+
+test('supportsAsk - only agent and claude are relayable', () => {
+  assert.equal(supportsAsk({ tool: 'agent' }), true);
+  assert.equal(supportsAsk({ tool: 'claude' }), true);
+  assert.equal(supportsAsk({ tool: 'codex' }), false);
+  assert.equal(supportsAsk({ tool: 'qwen' }), false);
+  assert.equal(supportsAsk({ tool: 'gemini' }), false);
+  assert.equal(supportsAsk({ tool: 'opencode' }), false);
+  assert.deepEqual([...ASK_SUPPORTED_TOOLS], ['agent', 'claude']);
+});
+
+test('askUnsupportedError - mentions the tool and supported tools', () => {
+  const message = askUnsupportedError({ tool: 'codex' });
+  assert.match(message, /Tool "codex"/);
+  assert.match(message, /per-command approval/);
+  assert.match(message, /agent, claude/);
+  assert.match(message, /--approve-each/);
+});
+
+test('ASK_DECISIONS - exactly once, always, reject', () => {
+  assert.deepEqual([...ASK_DECISIONS].sort(), ['always', 'once', 'reject']);
+});
+
+test('ASK_SCOPE - documents per-backend always semantics', () => {
+  assert.equal(ASK_SCOPE.agent, 'session');
+  assert.equal(ASK_SCOPE.claude, 'tool-input');
+});
+
+test('normalizePermissionRequest - agent permission_request', () => {
+  const message = {
+    type: 'permission_request',
+    permissionID: 'perm-1',
+    sessionID: 'sess-1',
+    callID: 'call-1',
+    tool: 'bash',
+    title: 'Run a command',
+    pattern: 'rm *',
+    metadata: { command: 'rm -rf build' },
+  };
+
+  const normalized = normalizePermissionRequest({ tool: 'agent', message });
+  assert.equal(normalized.type, 'permission_request');
+  assert.equal(normalized.tool, 'agent');
+  assert.equal(normalized.id, 'perm-1');
+  assert.equal(normalized.sessionId, 'sess-1');
+  assert.equal(normalized.callId, 'call-1');
+  assert.equal(normalized.toolName, 'bash');
+  assert.equal(normalized.title, 'Run a command');
+  assert.equal(normalized.command, 'rm -rf build');
+  assert.equal(normalized.pattern, 'rm *');
+  assert.equal(normalized.scope, 'session');
+  assert.equal(normalized.input, null);
+  assert.deepEqual(normalized.raw, message);
+});
+
+test('normalizePermissionRequest - agent snake_case permission_id fallback', () => {
+  const normalized = normalizePermissionRequest({
+    tool: 'agent',
+    message: {
+      type: 'permission_request',
+      permission_id: 'perm-2',
+      tool: 'edit',
+    },
+  });
+  assert.equal(normalized.id, 'perm-2');
+  assert.equal(normalized.toolName, 'edit');
+});
+
+test('normalizePermissionRequest - agent ignores non-permission messages', () => {
+  assert.equal(
+    normalizePermissionRequest({
+      tool: 'agent',
+      message: { type: 'step_finish' },
+    }),
+    null
+  );
+});
+
+test('normalizePermissionRequest - claude can_use_tool control_request', () => {
+  const message = {
+    type: 'control_request',
+    request_id: 'req-9',
+    session_id: 'sess-9',
+    request: {
+      subtype: 'can_use_tool',
+      tool_use_id: 'tu-9',
+      tool_name: 'Bash',
+      input: { command: 'npm test' },
+    },
+  };
+
+  const normalized = normalizePermissionRequest({ tool: 'claude', message });
+  assert.equal(normalized.tool, 'claude');
+  assert.equal(normalized.id, 'req-9');
+  assert.equal(normalized.sessionId, 'sess-9');
+  assert.equal(normalized.callId, 'tu-9');
+  assert.equal(normalized.toolName, 'Bash');
+  assert.equal(normalized.command, 'npm test');
+  assert.equal(normalized.scope, 'tool-input');
+  assert.deepEqual(normalized.input, { command: 'npm test' });
+});
+
+test('normalizePermissionRequest - claude derives command from file_path', () => {
+  const normalized = normalizePermissionRequest({
+    tool: 'claude',
+    message: {
+      type: 'control_request',
+      request_id: 'req-10',
+      request: {
+        subtype: 'can_use_tool',
+        tool_name: 'Edit',
+        input: { file_path: '/tmp/a.txt' },
+      },
+    },
+  });
+  assert.equal(normalized.command, '/tmp/a.txt');
+});
+
+test('normalizePermissionRequest - claude ignores unrelated control_request', () => {
+  assert.equal(
+    normalizePermissionRequest({
+      tool: 'claude',
+      message: {
+        type: 'control_request',
+        request: { subtype: 'initialize' },
+      },
+    }),
+    null
+  );
+});
+
+test('buildPermissionResponse - agent maps decisions verbatim', () => {
+  const request = { id: 'perm-1' };
+  for (const decision of ['once', 'always', 'reject']) {
+    const frame = buildPermissionResponse({ tool: 'agent', request, decision });
+    assert.deepEqual(frame, {
+      type: 'permission_response',
+      permissionID: 'perm-1',
+      response: decision,
+    });
+  }
+});
+
+test('buildPermissionResponse - claude reject denies', () => {
+  const frame = buildPermissionResponse({
+    tool: 'claude',
+    request: { id: 'req-1', input: { command: 'x' } },
+    decision: 'reject',
+  });
+  assert.equal(frame.type, 'control_response');
+  assert.equal(frame.response.subtype, 'success');
+  assert.equal(frame.response.request_id, 'req-1');
+  assert.equal(frame.response.response.behavior, 'deny');
+});
+
+test('buildPermissionResponse - claude once/always allow with input', () => {
+  for (const decision of ['once', 'always']) {
+    const frame = buildPermissionResponse({
+      tool: 'claude',
+      request: { id: 'req-2', input: { command: 'npm test' } },
+      decision,
+    });
+    assert.equal(frame.response.response.behavior, 'allow');
+    assert.deepEqual(frame.response.response.updatedInput, {
+      command: 'npm test',
+    });
+  }
+});
+
+test('buildPermissionResponse - rejects invalid decision', () => {
+  assert.throws(() => {
+    buildPermissionResponse({
+      tool: 'agent',
+      request: { id: 'x' },
+      decision: 'maybe',
+    });
+  }, /Invalid permission decision/);
+});
+
+test('buildPermissionResponse - rejects unsupported tool', () => {
+  assert.throws(() => {
+    buildPermissionResponse({
+      tool: 'codex',
+      request: { id: 'x' },
+      decision: 'once',
+    });
+  }, /does not support enforceable per-command approval/);
+});
+
+test('PERMISSION_PARITY - covers all six tools with scope and relay', () => {
+  const tools = PERMISSION_PARITY.map((row) => row.tool);
+  assert.deepEqual(tools.sort(), [
+    'agent',
+    'claude',
+    'codex',
+    'gemini',
+    'opencode',
+    'qwen',
+  ]);
+  for (const row of PERMISSION_PARITY) {
+    assert.ok(
+      typeof row.nativeMechanism === 'string' && row.nativeMechanism.length > 0
+    );
+    assert.ok(typeof row.scope === 'string' && row.scope.length > 0);
+    assert.equal(typeof row.relay, 'boolean');
+    assert.ok(typeof row.notes === 'string' && row.notes.length > 0);
+  }
+  const relayable = PERMISSION_PARITY.filter((row) => row.relay).map(
+    (row) => row.tool
+  );
+  assert.deepEqual(relayable.sort(), ['agent', 'claude']);
+});
+
+test('PermissionRelay - constructor validates required options', () => {
+  assert.throws(() => new PermissionRelay({}), /tool is required/);
+  assert.throws(
+    () => new PermissionRelay({ tool: 'agent' }),
+    /onRequest callback is required/
+  );
+  assert.throws(
+    () => new PermissionRelay({ tool: 'agent', onRequest: () => {} }),
+    /write callback is required/
+  );
+});
+
+test('PermissionRelay - relays an agent request and writes the response', async () => {
+  const written = [];
+  const relay = new PermissionRelay({
+    tool: 'agent',
+    onRequest: (request) => {
+      assert.equal(request.id, 'perm-1');
+      assert.equal(request.command, 'rm -rf build');
+      return 'always';
+    },
+    write: (line) => written.push(line),
+  });
+
+  const record = await relay.handleMessage({
+    message: {
+      type: 'permission_request',
+      permissionID: 'perm-1',
+      tool: 'bash',
+      metadata: { command: 'rm -rf build' },
+    },
+  });
+
+  assert.equal(record.decision, 'always');
+  assert.equal(written.length, 1);
+  const frame = JSON.parse(written[0]);
+  assert.deepEqual(frame, {
+    type: 'permission_response',
+    permissionID: 'perm-1',
+    response: 'always',
+  });
+  assert.equal(relay.getHandled().length, 1);
+});
+
+test('PermissionRelay - ignores non-permission messages', async () => {
+  const written = [];
+  const relay = new PermissionRelay({
+    tool: 'agent',
+    onRequest: () => 'once',
+    write: (line) => written.push(line),
+  });
+
+  const result = await relay.handleMessage({
+    message: { type: 'step_finish' },
+  });
+  assert.equal(result, null);
+  assert.equal(written.length, 0);
+});
+
+test('PermissionRelay - defaults invalid consumer decision to reject', async () => {
+  const written = [];
+  const relay = createPermissionRelay({
+    tool: 'claude',
+    onRequest: () => 'banana',
+    write: (line) => written.push(line),
+  });
+
+  const record = await relay.handleMessage({
+    message: {
+      type: 'control_request',
+      request_id: 'req-1',
+      request: {
+        subtype: 'can_use_tool',
+        tool_name: 'Bash',
+        input: { command: 'x' },
+      },
+    },
+  });
+
+  assert.equal(record.decision, 'reject');
+  const frame = JSON.parse(written[0]);
+  assert.equal(frame.response.response.behavior, 'deny');
+});
+
+test('PermissionRelay - claude allow forwards updatedInput', async () => {
+  const written = [];
+  const relay = new PermissionRelay({
+    tool: 'claude',
+    onRequest: () => 'once',
+    write: (line) => written.push(line),
+  });
+
+  await relay.handleMessage({
+    message: {
+      type: 'control_request',
+      request_id: 'req-2',
+      request: {
+        subtype: 'can_use_tool',
+        tool_name: 'Bash',
+        input: { command: 'npm test' },
+      },
+    },
+  });
+
+  const frame = JSON.parse(written[0]);
+  assert.equal(frame.response.response.behavior, 'allow');
+  assert.deepEqual(frame.response.response.updatedInput, {
+    command: 'npm test',
+  });
+});

--- a/js/test/tools.test.mjs
+++ b/js/test/tools.test.mjs
@@ -322,6 +322,38 @@ test('agentTool - buildArgs without read-only omits permission mode', () => {
   assert.ok(!args.includes('--permission-mode'));
 });
 
+test('agentTool - supportsAsk is true', () => {
+  assert.strictEqual(agentTool.supportsAsk, true);
+});
+
+test('agentTool - buildArgs approve-each uses ask mode and stream-json input', () => {
+  const args = agentTool.buildArgs({ approveEach: true });
+  const idx = args.indexOf('--permission-mode');
+  assert.ok(idx !== -1);
+  assert.strictEqual(args[idx + 1], 'ask');
+  assert.ok(args.includes('--input-format'));
+  assert.ok(args.includes('stream-json'));
+});
+
+test('claudeTool - supportsAsk is true', () => {
+  assert.strictEqual(claudeTool.supportsAsk, true);
+});
+
+test('claudeTool - buildArgs approve-each keeps default permission mode', () => {
+  const args = claudeTool.buildArgs({ approveEach: true });
+  const idx = args.indexOf('--permission-mode');
+  assert.ok(idx !== -1);
+  assert.strictEqual(args[idx + 1], 'default');
+  assert.ok(!args.includes('--dangerously-skip-permissions'));
+});
+
+test('non-relayable tools do not advertise supportsAsk', () => {
+  assert.notStrictEqual(codexTool.supportsAsk, true);
+  assert.notStrictEqual(qwenTool.supportsAsk, true);
+  assert.notStrictEqual(geminiTool.supportsAsk, true);
+  assert.notStrictEqual(opencodeTool.supportsAsk, true);
+});
+
 test('agentTool - extractUsage from step_finish events', () => {
   const output = `{"type":"step_finish","part":{"tokens":{"input":100,"output":50},"cost":0}}
 {"type":"step_finish","part":{"tokens":{"input":200,"output":75},"cost":0}}`;

--- a/rust/README.md
+++ b/rust/README.md
@@ -43,6 +43,7 @@ Common options:
 - `--prompt-file <path>`: read prompt input from a file for stdin-based tools
 - `--model <name>`: tool-specific model alias or full model name
 - `--read-only` or `--plan-only`: enforce native planning/no-write mode when supported
+- `--approve-each` (alias `--permission-mode ask`): approve each command, relaying native permission prompts as normalized NDJSON (supported for `agent` and `claude`)
 - `--tool-executable <path>`: override the native executable for any supported tool
 - `--tool-env <KEY=VALUE>`: add an environment variable to the native tool process, repeatable
 - `--tool-arg <arg>`: append a raw native tool argument, repeatable
@@ -116,8 +117,9 @@ JavaScript and Rust expose the same core concepts:
 - Dry-run command preview
 - JSON/NDJSON output parsing for tools that support it
 - Read-only planning mode for tools with enforceable native restrictions
+- Per-command approval (ask mode) with a normalized `permission_request`/`permission_response` relay for tools with a drivable native handshake
 
-See [shared concepts](../docs/common-concepts.md) for behavior that should stay aligned across both packages.
+See [shared concepts](../docs/common-concepts.md) for behavior that should stay aligned across both packages, including the [per-command approval parity table](../docs/common-concepts.md#per-command-approval-ask-mode).
 
 ## Release Flow
 

--- a/rust/changelog.d/20260617_140000_per_command_approval_relay.md
+++ b/rust/changelog.d/20260617_140000_per_command_approval_relay.md
@@ -1,0 +1,7 @@
+---
+bump: minor
+---
+
+### Added
+
+- Add a uniform per-command approval relay ("ask" mode). The new `--approve-each` flag (alias `--permission-mode ask`, `AgentOptions.approve_each`) maps to each backend's native per-command approval mechanism and relays native permission prompts as normalized `permission_request` events (carrying an opaque `id`, `tool`, `command`/`pattern`, `title`, and a `scope`), forwarding the consumer's normalized decision (`once` | `always` | `reject`) back in the native wire format. Supported (relayable) for `agent` (`--permission-mode ask` + `--input-format stream-json`, scope `session`) and `claude` (stream-json `can_use_tool`, scope `tool-input`); rejected with a clear error for `codex`, `qwen`, `gemini`, and `opencode`. Adds a `permissions` module (`normalize_permission_request`, `build_permission_response`, `PermissionRelay`, `permission_parity`, `supports_ask`, `ASK_DECISIONS`, `ask_scope`).

--- a/rust/src/bin/start_agent.rs
+++ b/rust/src/bin/start_agent.rs
@@ -65,6 +65,7 @@ async fn main() {
         fork_session: options.fork_session,
         read_only: options.read_only,
         plan_only: options.plan_only,
+        approve_each: options.approve_each,
         executable: options.tool_executable,
         extra_args: options.tool_args,
         extra_env,

--- a/rust/src/cli_parser.rs
+++ b/rust/src/cli_parser.rs
@@ -89,6 +89,8 @@ pub struct StartAgentOptions {
     pub replay_user_messages: bool,
     pub read_only: bool,
     pub plan_only: bool,
+    /// Approve each command (ask mode); relayable only for: claude, agent
+    pub approve_each: bool,
     pub resume: Option<String>,
     pub session_id: Option<String>,
     pub fork_session: bool,
@@ -144,6 +146,11 @@ pub fn parse_start_agent_args(args: &[String]) -> StartAgentOptions {
         replay_user_messages: parsed.get_bool("replay-user-messages"),
         read_only: parsed.get_bool("read-only") || parsed.get_bool("plan-only"),
         plan_only: parsed.get_bool("plan-only"),
+        approve_each: parsed.get_bool("approve-each")
+            || parsed
+                .get("permission-mode")
+                .map(|m| m == "ask")
+                .unwrap_or(false),
         resume: parsed.get("resume").cloned(),
         session_id: parsed.get("session-id").cloned(),
         fork_session: parsed.get_bool("fork-session"),
@@ -198,6 +205,8 @@ Options:
   --verbose                        Enable verbose mode
   --read-only                      Enforce native read-only mode (agent: --permission-mode readonly)
   --plan-only                      Enforce native planning mode (agent: --permission-mode plan)
+  --approve-each                   Approve each command (ask mode); relayable for: claude, agent
+  --permission-mode ask            Alias for --approve-each
   --resume <sessionId>             Resume a previous session by ID
   --session-id <uuid>              Use a specific session ID (must be valid UUID)
   --fork-session                   Create new session ID when resuming
@@ -466,6 +475,50 @@ mod tests {
             vec!["--mcp-config".to_string(), "/tmp/mcp.json".to_string()]
         );
         assert!(result.skip_default_safety_flags);
+    }
+
+    #[test]
+    fn test_parse_start_agent_args_approve_each() {
+        let args: Vec<String> = vec![
+            "--tool".into(),
+            "claude".into(),
+            "--working-directory".into(),
+            "/tmp/test".into(),
+            "--approve-each".into(),
+        ];
+        let result = parse_start_agent_args(&args);
+
+        assert!(result.approve_each);
+    }
+
+    #[test]
+    fn test_parse_start_agent_args_permission_mode_ask_alias() {
+        let args: Vec<String> = vec![
+            "--tool".into(),
+            "claude".into(),
+            "--working-directory".into(),
+            "/tmp/test".into(),
+            "--permission-mode".into(),
+            "ask".into(),
+        ];
+        let result = parse_start_agent_args(&args);
+
+        assert!(result.approve_each);
+    }
+
+    #[test]
+    fn test_parse_start_agent_args_permission_mode_other_is_not_approve_each() {
+        let args: Vec<String> = vec![
+            "--tool".into(),
+            "claude".into(),
+            "--working-directory".into(),
+            "/tmp/test".into(),
+            "--permission-mode".into(),
+            "default".into(),
+        ];
+        let result = parse_start_agent_args(&args);
+
+        assert!(!result.approve_each);
     }
 
     #[test]

--- a/rust/src/command_builder.rs
+++ b/rust/src/command_builder.rs
@@ -29,6 +29,8 @@ pub struct AgentCommandOptions {
     pub fork_session: bool,
     pub read_only: bool,
     pub plan_only: bool,
+    /// Approve each mutating command (`--permission-mode ask` / `--approve-each`)
+    pub approve_each: bool,
     pub executable: Option<String>,
     pub extra_args: Vec<String>,
     pub extra_env: Vec<(String, String)>,
@@ -167,6 +169,15 @@ pub fn build_agent_command(options: &AgentCommandOptions) -> String {
         read_only_unsupported_error(&options.tool)
     );
 
+    // Per-command approval ("ask" mode) is only enforceable on tools that expose
+    // a drivable JSON permission request/response protocol (agent, claude). Fail
+    // clearly for the rest, mirroring the --read-only gate above.
+    assert!(
+        !(options.approve_each && !crate::permissions::supports_ask(&options.tool)),
+        "{}",
+        crate::permissions::ask_unsupported_error(&options.tool)
+    );
+
     // Build base command using tool-specific builder if available
     let base_command = if is_tool_supported(&options.tool) {
         match options.tool.as_str() {
@@ -186,11 +197,13 @@ pub fn build_agent_command(options: &AgentCommandOptions) -> String {
                 fork_session: options.fork_session,
                 print: false,
                 read_only: read_only_requested,
+                approve_each: options.approve_each,
                 executable: options.executable.clone(),
                 extra_env: options.extra_env.clone(),
                 extra_args: options.extra_args.clone(),
                 skip_default_safety_flags: options.skip_default_safety_flags,
                 permission_mode: None,
+                stream_input: false,
             }),
             "codex" => codex::build_command(&CodexBuildOptions {
                 prompt: options.prompt.clone(),
@@ -228,8 +241,10 @@ pub fn build_agent_command(options: &AgentCommandOptions) -> String {
                 use_existing_claude_oauth: false,
                 read_only: read_only_requested,
                 plan_only: options.plan_only,
+                approve_each: options.approve_each,
                 permission_mode: None,
                 permission: None,
+                stream_input: false,
                 executable: options.executable.clone(),
                 extra_env: options.extra_env.clone(),
                 extra_args: options.extra_args.clone(),
@@ -838,6 +853,74 @@ mod tests {
         assert!(command.contains("--permission-mode"));
         assert!(command.contains("plan"));
         assert!(!command.contains("readonly"));
+    }
+
+    #[test]
+    fn test_build_agent_command_agent_approve_each_uses_ask_mode() {
+        let options = AgentCommandOptions {
+            tool: "agent".to_string(),
+            working_directory: "/tmp/test".to_string(),
+            prompt: Some("Do work".to_string()),
+            approve_each: true,
+            isolation: "none".to_string(),
+            ..Default::default()
+        };
+
+        let command = build_agent_command(&options);
+        assert!(command.contains("--permission-mode"));
+        assert!(command.contains("ask"));
+        // Ask mode requires streaming stdin so requests can be answered mid-turn.
+        assert!(command.contains("--input-format"));
+        assert!(command.contains("stream-json"));
+        assert!(!command.contains("readonly"));
+    }
+
+    #[test]
+    fn test_build_agent_command_claude_approve_each_uses_default_mode() {
+        let options = AgentCommandOptions {
+            tool: "claude".to_string(),
+            working_directory: "/tmp/test".to_string(),
+            prompt: Some("Do work".to_string()),
+            approve_each: true,
+            isolation: "none".to_string(),
+            ..Default::default()
+        };
+
+        let command = build_agent_command(&options);
+        assert!(command.contains("--permission-mode"));
+        assert!(command.contains("default"));
+        // Default mode keeps Claude's own per-tool prompting active instead of
+        // bypassing it.
+        assert!(!command.contains("--dangerously-skip-permissions"));
+        assert!(!command.contains("plan"));
+    }
+
+    #[test]
+    #[should_panic(expected = "does not support enforceable per-command approval")]
+    fn test_build_agent_command_approve_each_rejects_codex() {
+        let options = AgentCommandOptions {
+            tool: "codex".to_string(),
+            working_directory: "/tmp/test".to_string(),
+            approve_each: true,
+            isolation: "none".to_string(),
+            ..Default::default()
+        };
+
+        let _command = build_agent_command(&options);
+    }
+
+    #[test]
+    #[should_panic(expected = "does not support enforceable per-command approval")]
+    fn test_build_agent_command_approve_each_rejects_unknown_tool() {
+        let options = AgentCommandOptions {
+            tool: "unknown-tool".to_string(),
+            working_directory: "/tmp/test".to_string(),
+            approve_each: true,
+            isolation: "none".to_string(),
+            ..Default::default()
+        };
+
+        let _command = build_agent_command(&options);
     }
 
     #[test]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -12,6 +12,7 @@
 pub mod cli_parser;
 pub mod command_builder;
 pub mod executor;
+pub mod permissions;
 pub mod result_metadata;
 pub mod streaming;
 pub mod tools;
@@ -30,6 +31,12 @@ pub use cli_parser::{
 pub use command_builder::{
     build_agent_command, build_docker_stop_command, build_piped_command, build_screen_stop_command,
     read_only_unsupported_error, supports_read_only, AgentCommandOptions,
+};
+
+pub use permissions::{
+    ask_scope, ask_unsupported_error, build_permission_response, normalize_permission_request,
+    permission_parity, supports_ask, NormalizedPermissionRequest, PermissionParityRow,
+    PermissionRelay, ASK_DECISIONS, ASK_SUPPORTED_TOOLS,
 };
 
 pub use executor::{
@@ -92,6 +99,9 @@ pub struct AgentOptions {
     pub read_only: bool,
     /// Enforce native planning mode (where the tool distinguishes it)
     pub plan_only: bool,
+    /// Approve each mutating command (ask mode), relayed over the tool's native
+    /// per-command JSON permission protocol (only `claude` and `agent`)
+    pub approve_each: bool,
     /// Override the tool executable path/name
     pub executable: Option<String>,
     /// Extra raw arguments appended after typed tool arguments
@@ -248,6 +258,9 @@ impl Agent {
         if (options.read_only || options.plan_only) && !supports_read_only(&options.tool) {
             return Err(read_only_unsupported_error(&options.tool));
         }
+        if options.approve_each && !supports_ask(&options.tool) {
+            return Err(ask_unsupported_error(&options.tool));
+        }
 
         Ok(Self {
             options,
@@ -355,6 +368,7 @@ impl Agent {
             fork_session: self.options.fork_session,
             read_only: self.options.read_only,
             plan_only: self.options.plan_only,
+            approve_each: self.options.approve_each,
             executable: self.options.executable.clone(),
             extra_args: self.options.extra_args.clone(),
             extra_env: self.options.extra_env.clone(),

--- a/rust/src/permissions.rs
+++ b/rust/src/permissions.rs
@@ -1,0 +1,384 @@
+//! Permission normalization and relay for the uniform per-command approval
+//! ("ask") mode.
+//!
+//! Each backend CLI that supports interactive, per-command approval exposes the
+//! approval handshake over a different JSON wire format. This module translates
+//! those native frames into a single normalized `permission_request` event and
+//! translates a normalized decision (`once` | `always` | `reject`) back into the
+//! native response frame that the CLI expects on its stdin.
+//!
+//! Only tools with a *drivable* JSON request/response permission protocol can be
+//! relayed (see [`ASK_SUPPORTED_TOOLS`]). Tools whose only native approval
+//! mechanism is a static policy (`opencode`), a sandbox coupling (`codex`), or a
+//! non-streaming approval flag (`qwen`, `gemini`) are documented in the parity
+//! table but fail clearly when ask mode is requested — mirroring the
+//! `--read-only` unsupported-tool pattern.
+//!
+//! This is the Rust mirror of `js/src/permissions/`.
+
+use crate::streaming::stringify_ndjson_line;
+use serde_json::{json, Value};
+
+/// Tools that expose a relayable per-command approval protocol over JSON.
+pub const ASK_SUPPORTED_TOOLS: &[&str] = &["agent", "claude"];
+
+/// Normalized decisions a consumer may return for a permission request.
+pub const ASK_DECISIONS: &[&str] = &["once", "always", "reject"];
+
+/// Scope of an `always` decision for each backend. The reviewer (m13v) flagged
+/// that "always" does not mean the same thing across CLIs, so the normalized
+/// event and the parity table both carry this scope.
+///
+/// - `session`    — `always` auto-approves later matching requests for the rest
+///   of the session (agent's native `always`).
+/// - `tool-input` — approval binds to the tool name + input shape; Claude has no
+///   native session-wide `always`, so `once` and `always` both map to a single
+///   allow decision bound to that tool call's input.
+pub fn ask_scope(tool: &str) -> Option<&'static str> {
+    match tool {
+        "agent" => Some("session"),
+        "claude" => Some("tool-input"),
+        _ => None,
+    }
+}
+
+/// Whether agent-commander can relay per-command approvals for the given tool.
+pub fn supports_ask(tool: &str) -> bool {
+    ASK_SUPPORTED_TOOLS.contains(&tool)
+}
+
+/// Build the standard error for tools without a relayable per-command approval
+/// mechanism (ask mode). Mirrors [`crate::command_builder::read_only_unsupported_error`].
+pub fn ask_unsupported_error(tool: &str) -> String {
+    format!(
+        "Tool \"{}\" does not support enforceable per-command approval (ask mode). Choose one of: {}; or run without --approve-each.",
+        tool,
+        ASK_SUPPORTED_TOOLS.join(", ")
+    )
+}
+
+/// A normalized permission request, uniform across every relayable backend.
+// `raw`/`input` carry `serde_json::Value`, which cannot implement `Eq`.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Debug, Clone, PartialEq)]
+pub struct NormalizedPermissionRequest {
+    /// Always `"permission_request"`.
+    pub r#type: String,
+    /// Backend tool name (`agent` | `claude`).
+    pub tool: String,
+    /// Opaque id used to correlate the response with this request.
+    pub id: Option<String>,
+    pub session_id: Option<String>,
+    pub call_id: Option<String>,
+    /// Native tool/action name (e.g. `bash`, `Edit`).
+    pub tool_name: Option<String>,
+    pub title: Option<String>,
+    /// Best-effort human-readable command/target string.
+    pub command: Option<String>,
+    pub pattern: Option<String>,
+    /// What an `always`/allow decision attaches to (see [`ask_scope`]).
+    pub scope: String,
+    /// Original tool input payload (Claude only), needed to echo `updatedInput`.
+    pub input: Option<Value>,
+    /// The raw native frame this was normalized from.
+    pub raw: Value,
+}
+
+fn value_str(message: &Value, key: &str) -> Option<String> {
+    message
+        .get(key)
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+}
+
+/// Derive a human-readable command string from a Claude tool input payload.
+fn derive_claude_command(tool_name: Option<&str>, input: Option<&Value>) -> Option<String> {
+    if let Some(input) = input {
+        // Bash carries the literal shell command.
+        for key in ["command", "file_path", "path", "url"] {
+            if let Some(value) = input.get(key).and_then(|v| v.as_str()) {
+                return Some(value.to_string());
+            }
+        }
+    }
+    tool_name.map(|s| s.to_string())
+}
+
+/// Normalize a native permission request frame into a uniform event.
+///
+/// Returns `None` when the message is not a permission request for the tool, so
+/// callers can pass every parsed output message through unconditionally.
+pub fn normalize_permission_request(
+    tool: &str,
+    message: &Value,
+) -> Option<NormalizedPermissionRequest> {
+    if !message.is_object() {
+        return None;
+    }
+
+    if tool == "agent" {
+        if message.get("type").and_then(|v| v.as_str()) != Some("permission_request") {
+            return None;
+        }
+        let id = value_str(message, "permissionID").or_else(|| value_str(message, "permission_id"));
+        let metadata = message.get("metadata").filter(|v| v.is_object());
+        let title = value_str(message, "title");
+        let command = metadata
+            .and_then(|m| m.get("command"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .or_else(|| title.clone());
+        let pattern = value_str(message, "pattern").or_else(|| {
+            metadata
+                .and_then(|m| m.get("patterns"))
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+        });
+        return Some(NormalizedPermissionRequest {
+            r#type: "permission_request".to_string(),
+            tool: "agent".to_string(),
+            id,
+            session_id: value_str(message, "sessionID")
+                .or_else(|| value_str(message, "session_id")),
+            call_id: value_str(message, "callID").or_else(|| value_str(message, "call_id")),
+            tool_name: value_str(message, "tool"),
+            title,
+            command,
+            pattern,
+            scope: ask_scope("agent").unwrap().to_string(),
+            input: None,
+            raw: message.clone(),
+        });
+    }
+
+    if tool == "claude" {
+        let request = message.get("request");
+        let is_can_use_tool = message.get("type").and_then(|v| v.as_str())
+            == Some("control_request")
+            && request
+                .and_then(|r| r.get("subtype"))
+                .and_then(|v| v.as_str())
+                == Some("can_use_tool");
+        if !is_can_use_tool {
+            return None;
+        }
+        let request = request.unwrap();
+        let tool_name = request
+            .get("tool_name")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let input = request.get("input").filter(|v| v.is_object()).cloned();
+        return Some(NormalizedPermissionRequest {
+            r#type: "permission_request".to_string(),
+            tool: "claude".to_string(),
+            id: value_str(message, "request_id"),
+            session_id: value_str(message, "session_id"),
+            call_id: request
+                .get("tool_use_id")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string()),
+            tool_name: tool_name.clone(),
+            title: tool_name.clone(),
+            command: derive_claude_command(tool_name.as_deref(), input.as_ref()),
+            pattern: None,
+            scope: ask_scope("claude").unwrap().to_string(),
+            input,
+            raw: message.clone(),
+        });
+    }
+
+    None
+}
+
+/// Build the native response frame for a normalized decision.
+///
+/// Returns `Err` for an invalid decision or an unsupported tool.
+pub fn build_permission_response(
+    tool: &str,
+    request: &NormalizedPermissionRequest,
+    decision: &str,
+) -> Result<Value, String> {
+    if !ASK_DECISIONS.contains(&decision) {
+        return Err(format!(
+            "Invalid permission decision \"{}\". Expected one of: once, always, reject.",
+            decision
+        ));
+    }
+
+    let id = request.id.clone().unwrap_or_default();
+
+    if tool == "agent" {
+        // Agent's native protocol accepts once | always | reject verbatim.
+        return Ok(json!({
+            "type": "permission_response",
+            "permissionID": id,
+            "response": decision,
+        }));
+    }
+
+    if tool == "claude" {
+        // Claude's stream-json control protocol expects an allow/deny behavior.
+        // It has no native session-wide "always", so once and always both map to
+        // a single allow bound to this tool call's input (scope: tool-input).
+        if decision == "reject" {
+            return Ok(json!({
+                "type": "control_response",
+                "response": {
+                    "subtype": "success",
+                    "request_id": id,
+                    "response": {
+                        "behavior": "deny",
+                        "message": "Denied by consumer (ask mode).",
+                    },
+                },
+            }));
+        }
+        let updated_input = request.input.clone().unwrap_or_else(|| json!({}));
+        return Ok(json!({
+            "type": "control_response",
+            "response": {
+                "subtype": "success",
+                "request_id": id,
+                "response": {
+                    "behavior": "allow",
+                    "updatedInput": updated_input,
+                },
+            },
+        }));
+    }
+
+    Err(ask_unsupported_error(tool))
+}
+
+/// A single row of the per-command approval parity table.
+#[derive(Debug, Clone)]
+pub struct PermissionParityRow {
+    pub tool: &'static str,
+    pub native_mechanism: &'static str,
+    pub scope: &'static str,
+    pub relay: bool,
+    pub notes: &'static str,
+}
+
+/// Parity description for each tool's native per-command approval mechanism.
+///
+/// Surfaced in the docs parity table; `scope` documents what an `always`/allow
+/// decision attaches to, and `relay` indicates whether agent-commander can drive
+/// the handshake as normalized JSON.
+pub fn permission_parity() -> Vec<PermissionParityRow> {
+    vec![
+        PermissionParityRow {
+            tool: "agent",
+            native_mechanism: "--permission-mode ask (+ --input-format stream-json)",
+            scope: "session",
+            relay: true,
+            notes: "Native JSON permission_request/permission_response protocol; once | always | reject map 1:1.",
+        },
+        PermissionParityRow {
+            tool: "claude",
+            native_mechanism: "--permission-mode default (stream-json can_use_tool)",
+            scope: "tool-input",
+            relay: true,
+            notes: "control_request/control_response handshake; no session-wide always, so once and always both allow this call.",
+        },
+        PermissionParityRow {
+            tool: "codex",
+            native_mechanism: "--ask-for-approval (coupled with --sandbox)",
+            scope: "sandbox-coupled",
+            relay: false,
+            notes: "Approval is coupled with the sandbox policy and not exposed as a tool-agnostic JSON request/response stream.",
+        },
+        PermissionParityRow {
+            tool: "qwen",
+            native_mechanism: "--approval-mode default",
+            scope: "interactive-only",
+            relay: false,
+            notes: "Headless mode has no relayable per-command JSON approval handshake.",
+        },
+        PermissionParityRow {
+            tool: "gemini",
+            native_mechanism: "--approval-mode default",
+            scope: "interactive-only",
+            relay: false,
+            notes: "No JSON stdin channel (prompt is passed via -p), so approvals cannot be relayed.",
+        },
+        PermissionParityRow {
+            tool: "opencode",
+            native_mechanism: "OPENCODE_PERMISSION (static {edit,bash,task} policy)",
+            scope: "static-policy",
+            relay: false,
+            notes: "Only a static up-front policy is available; there is no per-command request/response relay.",
+        },
+    ]
+}
+
+/// Relay native permission requests to a consumer and forward decisions back.
+///
+/// A `PermissionRelay` sits between a backend CLI's streaming output and a
+/// consumer: it watches parsed output messages for native permission requests,
+/// normalizes them, asks the consumer for a decision, and writes the native
+/// response frame back to the CLI's stdin as NDJSON.
+///
+/// The relay is intentionally transport-agnostic — it does not own the child
+/// process. The caller supplies a `write` closure (typically the child's stdin)
+/// and feeds it parsed messages, which keeps it fully unit-testable.
+pub struct PermissionRelay<'a> {
+    tool: String,
+    on_request: Box<dyn FnMut(&NormalizedPermissionRequest) -> String + 'a>,
+    write: Box<dyn FnMut(&str) + 'a>,
+    compact: bool,
+    handled: Vec<(NormalizedPermissionRequest, String, Value)>,
+}
+
+impl<'a> PermissionRelay<'a> {
+    /// Create a new relay.
+    ///
+    /// * `on_request` resolves a normalized request to a decision
+    ///   (`once` | `always` | `reject`).
+    /// * `write` receives a serialized NDJSON frame to forward to the tool stdin.
+    pub fn new<F, W>(tool: &str, on_request: F, write: W) -> Self
+    where
+        F: FnMut(&NormalizedPermissionRequest) -> String + 'a,
+        W: FnMut(&str) + 'a,
+    {
+        Self {
+            tool: tool.to_string(),
+            on_request: Box::new(on_request),
+            write: Box::new(write),
+            compact: true,
+            handled: Vec::new(),
+        }
+    }
+
+    /// Process a single parsed output message. When the message is a permission
+    /// request, resolves the consumer's decision and writes the native response.
+    /// Returns the normalized request and the applied decision, or `None` when the
+    /// message is not a permission request.
+    pub fn handle_message(
+        &mut self,
+        message: &Value,
+    ) -> Option<(NormalizedPermissionRequest, String)> {
+        let request = normalize_permission_request(&self.tool, message)?;
+
+        let mut decision = (self.on_request)(&request);
+        // Default to the safe choice if the consumer returns nothing usable.
+        if !ASK_DECISIONS.contains(&decision.as_str()) {
+            decision = "reject".to_string();
+        }
+
+        // build_permission_response only fails for unsupported tools / decisions,
+        // both of which are excluded above, so the frame is always available here.
+        let frame = build_permission_response(&self.tool, &request, &decision)
+            .expect("relayable tool with validated decision");
+        (self.write)(&stringify_ndjson_line(&frame, self.compact));
+
+        self.handled
+            .push((request.clone(), decision.clone(), frame));
+        Some((request, decision))
+    }
+
+    /// All permission requests handled so far (for inspection/testing).
+    pub fn get_handled(&self) -> &[(NormalizedPermissionRequest, String, Value)] {
+        &self.handled
+    }
+}

--- a/rust/src/tools/agent.rs
+++ b/rust/src/tools/agent.rs
@@ -71,10 +71,15 @@ pub struct AgentBuildOptions {
     pub read_only: bool,
     /// Enforce planning mode (`--permission-mode plan`)
     pub plan_only: bool,
+    /// Approve each mutating command (`--permission-mode ask`)
+    pub approve_each: bool,
     /// Explicit agent permission mode (auto | plan | readonly | ask)
     pub permission_mode: Option<String>,
     /// OpenCode-compatible `--permission` JSON policy
     pub permission: Option<String>,
+    /// Caller owns the child's stdin and streams the prompt + permission
+    /// responses as NDJSON frames, so no prompt is piped in `build_command`.
+    pub stream_input: bool,
     pub executable: Option<String>,
     pub extra_env: Vec<(String, String)>,
     pub extra_args: Vec<String>,
@@ -92,9 +97,13 @@ pub fn build_args(options: &AgentBuildOptions) -> Vec<String> {
 
     // Native, enforceable permission system (agent v0.24.0, PR #272).
     // --plan-only maps to `plan`, --read-only maps to the harder `readonly`,
-    // matching agent's own distinction between the two modes.
+    // --approve-each maps to `ask` (per-command approval relayed over JSON),
+    // matching agent's own distinction between the modes. An explicit
+    // permission_mode always wins.
     let resolved_permission_mode = options.permission_mode.clone().or_else(|| {
-        if options.plan_only {
+        if options.approve_each {
+            Some("ask".to_string())
+        } else if options.plan_only {
             Some("plan".to_string())
         } else if options.read_only {
             Some("readonly".to_string())
@@ -102,9 +111,17 @@ pub fn build_args(options: &AgentBuildOptions) -> Vec<String> {
             None
         }
     });
+    let is_ask = resolved_permission_mode.as_deref() == Some("ask");
     if let Some(mode) = resolved_permission_mode {
         args.push("--permission-mode".to_string());
         args.push(mode);
+    }
+
+    // Ask mode emits requests mid-turn and blocks until answered, so it requires
+    // a streaming input mode (single-shot prompt over stdin would deadlock).
+    if is_ask {
+        args.push("--input-format".to_string());
+        args.push("stream-json".to_string());
     }
 
     if let Some(ref permission) = options.permission {
@@ -142,6 +159,21 @@ pub fn build_args(options: &AgentBuildOptions) -> Vec<String> {
 pub fn build_command(options: &AgentBuildOptions) -> String {
     let args = build_args(options);
     let args_str: Vec<String> = args.iter().map(|a| escape_arg(a)).collect();
+    let executable = options.executable.as_deref().unwrap_or("agent");
+    let command_head = format!(
+        "{} {}",
+        build_command_head(executable, &options.extra_env, &[]),
+        args_str.join(" ")
+    )
+    .trim()
+    .to_string();
+
+    // In stream-input mode the caller owns the child's stdin and writes the
+    // prompt and permission responses as NDJSON frames (per-command approval
+    // relay), so no prompt is piped here.
+    if options.stream_input {
+        return command_head;
+    }
 
     // Agent expects prompt via stdin, combine system and user prompts
     let combined_prompt = match (&options.system_prompt, &options.prompt) {
@@ -156,15 +188,9 @@ pub fn build_command(options: &AgentBuildOptions) -> String {
         || format!("printf '%s' '{}'", escape_single_quotes(&combined_prompt)),
         |prompt_file| format!("cat {}", escape_arg(prompt_file)),
     );
-    let executable = options.executable.as_deref().unwrap_or("agent");
-    format!(
-        "{} | {} {}",
-        input_command,
-        build_command_head(executable, &options.extra_env, &[]),
-        args_str.join(" ")
-    )
-    .trim()
-    .to_string()
+    format!("{} | {}", input_command, command_head)
+        .trim()
+        .to_string()
 }
 
 /// Parse JSON messages from Agent output
@@ -309,6 +335,7 @@ pub struct AgentTool {
     pub supports_system_prompt: bool,
     pub supports_resume: bool,
     pub supports_read_only: bool,
+    pub supports_ask: bool,
     pub default_model: &'static str,
 }
 
@@ -323,6 +350,7 @@ impl Default for AgentTool {
             supports_system_prompt: false, // System prompt is combined with user prompt
             supports_resume: false,    // Agent doesn't have explicit resume like Claude
             supports_read_only: true, // Native --permission-mode readonly/plan (agent v0.24.0, PR #272)
+            supports_ask: true,       // Native --permission-mode ask with JSON permission relay
             default_model: "nemotron-3-super-free", // hive-mind issue #1563, agent PR #243
         }
     }

--- a/rust/src/tools/claude.rs
+++ b/rust/src/tools/claude.rs
@@ -65,11 +65,16 @@ pub struct ClaudeBuildOptions {
     pub session_id: Option<String>,
     pub fork_session: bool,
     pub read_only: bool,
+    /// Approve each command (`--permission-mode default` + stream-json relay)
+    pub approve_each: bool,
     pub executable: Option<String>,
     pub extra_env: Vec<(String, String)>,
     pub extra_args: Vec<String>,
     pub skip_default_safety_flags: bool,
     pub permission_mode: Option<String>,
+    /// Caller owns the child's stdin and streams the prompt + permission
+    /// responses as NDJSON frames, so no `--prompt` arg is passed.
+    pub stream_input: bool,
 }
 
 impl ClaudeBuildOptions {
@@ -89,7 +94,13 @@ impl ClaudeBuildOptions {
 pub fn build_args(options: &ClaudeBuildOptions) -> Vec<String> {
     let mut args = Vec::new();
 
-    if options.read_only {
+    if options.approve_each {
+        // Per-command approval: ask before each tool use via the stream-json
+        // can_use_tool control protocol. `default` keeps Claude's own prompting
+        // active instead of bypassing it; the relay answers each request.
+        args.push("--permission-mode".to_string());
+        args.push("default".to_string());
+    } else if options.read_only {
         args.push("--permission-mode".to_string());
         args.push("plan".to_string());
     } else if let Some(ref permission_mode) = options.permission_mode {
@@ -112,7 +123,9 @@ pub fn build_args(options: &ClaudeBuildOptions) -> Vec<String> {
         args.push(mapped_fallback);
     }
 
-    if options.prompt_file.is_none() {
+    // In stream-input mode the prompt is written to stdin as NDJSON frames by
+    // the per-command approval relay, so it is not passed as a --prompt arg.
+    if options.prompt_file.is_none() && !options.stream_input {
         if let Some(ref prompt) = options.prompt {
             args.push("--prompt".to_string());
             args.push(prompt.clone());
@@ -193,7 +206,12 @@ pub fn build_command(options: &ClaudeBuildOptions) -> String {
     .trim()
     .to_string();
 
-    if let Some(prompt_file) = &options.prompt_file {
+    // In stream-input mode the caller owns the child's stdin and writes the
+    // prompt and permission responses as NDJSON frames (per-command approval
+    // relay), so no prompt is piped here.
+    if options.stream_input {
+        command
+    } else if let Some(prompt_file) = &options.prompt_file {
         format!("cat {} | {}", escape_arg(prompt_file), command)
     } else {
         command
@@ -294,6 +312,7 @@ pub struct ClaudeTool {
     pub supports_verbose: bool,
     pub supports_replay_user_messages: bool,
     pub supports_read_only: bool,
+    pub supports_ask: bool,
     pub default_model: &'static str,
 }
 
@@ -314,6 +333,7 @@ impl Default for ClaudeTool {
             supports_verbose: true,        // Supports --verbose
             supports_replay_user_messages: true, // Supports --replay-user-messages
             supports_read_only: true,      // Supports --permission-mode plan
+            supports_ask: true, // Supports --permission-mode default with stream-json relay
             default_model: "sonnet",
         }
     }

--- a/rust/src/tools/codex.rs
+++ b/rust/src/tools/codex.rs
@@ -245,6 +245,7 @@ pub struct CodexTool {
     pub supports_system_prompt: bool,
     pub supports_resume: bool,
     pub supports_read_only: bool,
+    pub supports_ask: bool,
     pub default_model: &'static str,
 }
 
@@ -259,6 +260,7 @@ impl Default for CodexTool {
             supports_system_prompt: false, // System prompt is combined with user prompt
             supports_resume: true,
             supports_read_only: true, // Supports --sandbox read-only
+            supports_ask: false, // Approval is coupled with the sandbox, not a relayable JSON stream
             default_model: "gpt-5.5", // hive-mind PR #1657
         }
     }

--- a/rust/src/tools/gemini.rs
+++ b/rust/src/tools/gemini.rs
@@ -345,6 +345,7 @@ pub struct GeminiTool {
     pub supports_checkpointing: bool,
     pub supports_debug: bool,
     pub supports_read_only: bool,
+    pub supports_ask: bool,
     pub default_model: &'static str,
 }
 
@@ -363,6 +364,7 @@ impl Default for GeminiTool {
             supports_checkpointing: true, // Supports --checkpointing
             supports_debug: true,       // Supports -d for debug output
             supports_read_only: true,   // Supports --approval-mode plan
+            supports_ask: false, // Headless mode has no relayable per-command JSON approval handshake
             default_model: "gemini-2.5-flash",
         }
     }

--- a/rust/src/tools/opencode.rs
+++ b/rust/src/tools/opencode.rs
@@ -205,6 +205,7 @@ pub struct OpencodeTool {
     pub supports_system_prompt: bool,
     pub supports_resume: bool,
     pub supports_read_only: bool,
+    pub supports_ask: bool,
     pub default_model: &'static str,
 }
 
@@ -219,6 +220,7 @@ impl Default for OpencodeTool {
             supports_system_prompt: false, // System prompt is combined with user prompt
             supports_resume: true,
             supports_read_only: true, // Supports OPENCODE_PERMISSION
+            supports_ask: false, // OPENCODE_PERMISSION is env-based policy, not a relayable JSON approval stream
             default_model: "grok-code-fast-1",
         }
     }

--- a/rust/src/tools/qwen.rs
+++ b/rust/src/tools/qwen.rs
@@ -341,6 +341,7 @@ pub struct QwenTool {
     pub supports_include_directories: bool,
     pub supports_include_partial_messages: bool,
     pub supports_read_only: bool,
+    pub supports_ask: bool,
     pub default_model: &'static str,
 }
 
@@ -360,6 +361,7 @@ impl Default for QwenTool {
             supports_include_directories: true, // Supports --include-directories
             supports_include_partial_messages: true, // Supports --include-partial-messages
             supports_read_only: true,  // Supports --approval-mode plan
+            supports_ask: false, // Headless mode has no relayable per-command JSON approval handshake
             default_model: "qwen3-coder-480a35",
         }
     }

--- a/rust/tests/permissions_tests.rs
+++ b/rust/tests/permissions_tests.rs
@@ -1,0 +1,350 @@
+//! Tests for the uniform per-command approval ("ask" mode) permission relay.
+//! Rust mirror of `js/test/permissions.test.mjs`.
+
+use agent_commander::{
+    ask_scope, ask_unsupported_error, build_permission_response, normalize_permission_request,
+    permission_parity, supports_ask, NormalizedPermissionRequest, PermissionRelay, ASK_DECISIONS,
+    ASK_SUPPORTED_TOOLS,
+};
+use serde_json::json;
+
+#[test]
+fn supports_ask_only_agent_and_claude_are_relayable() {
+    assert!(supports_ask("agent"));
+    assert!(supports_ask("claude"));
+    assert!(!supports_ask("codex"));
+    assert!(!supports_ask("qwen"));
+    assert!(!supports_ask("gemini"));
+    assert!(!supports_ask("opencode"));
+    assert_eq!(ASK_SUPPORTED_TOOLS, &["agent", "claude"]);
+}
+
+#[test]
+fn ask_unsupported_error_mentions_tool_and_supported_tools() {
+    let message = ask_unsupported_error("codex");
+    assert!(message.contains("Tool \"codex\""));
+    assert!(message.contains("per-command approval"));
+    assert!(message.contains("agent, claude"));
+    assert!(message.contains("--approve-each"));
+}
+
+#[test]
+fn ask_decisions_exactly_once_always_reject() {
+    let mut decisions = ASK_DECISIONS.to_vec();
+    decisions.sort_unstable();
+    assert_eq!(decisions, vec!["always", "once", "reject"]);
+}
+
+#[test]
+fn ask_scope_documents_per_backend_always_semantics() {
+    assert_eq!(ask_scope("agent"), Some("session"));
+    assert_eq!(ask_scope("claude"), Some("tool-input"));
+    assert_eq!(ask_scope("codex"), None);
+}
+
+#[test]
+fn normalize_agent_permission_request() {
+    let message = json!({
+        "type": "permission_request",
+        "permissionID": "perm-1",
+        "sessionID": "sess-1",
+        "callID": "call-1",
+        "tool": "bash",
+        "title": "Run a command",
+        "pattern": "rm *",
+        "metadata": { "command": "rm -rf build" },
+    });
+
+    let normalized = normalize_permission_request("agent", &message).unwrap();
+    assert_eq!(normalized.r#type, "permission_request");
+    assert_eq!(normalized.tool, "agent");
+    assert_eq!(normalized.id.as_deref(), Some("perm-1"));
+    assert_eq!(normalized.session_id.as_deref(), Some("sess-1"));
+    assert_eq!(normalized.call_id.as_deref(), Some("call-1"));
+    assert_eq!(normalized.tool_name.as_deref(), Some("bash"));
+    assert_eq!(normalized.title.as_deref(), Some("Run a command"));
+    assert_eq!(normalized.command.as_deref(), Some("rm -rf build"));
+    assert_eq!(normalized.pattern.as_deref(), Some("rm *"));
+    assert_eq!(normalized.scope, "session");
+    assert_eq!(normalized.input, None);
+    assert_eq!(normalized.raw, message);
+}
+
+#[test]
+fn normalize_agent_snake_case_permission_id_fallback() {
+    let normalized = normalize_permission_request(
+        "agent",
+        &json!({ "type": "permission_request", "permission_id": "perm-2", "tool": "edit" }),
+    )
+    .unwrap();
+    assert_eq!(normalized.id.as_deref(), Some("perm-2"));
+    assert_eq!(normalized.tool_name.as_deref(), Some("edit"));
+}
+
+#[test]
+fn normalize_agent_ignores_non_permission_messages() {
+    assert!(normalize_permission_request("agent", &json!({ "type": "step_finish" })).is_none());
+}
+
+#[test]
+fn normalize_claude_can_use_tool_control_request() {
+    let message = json!({
+        "type": "control_request",
+        "request_id": "req-9",
+        "session_id": "sess-9",
+        "request": {
+            "subtype": "can_use_tool",
+            "tool_use_id": "tu-9",
+            "tool_name": "Bash",
+            "input": { "command": "npm test" },
+        },
+    });
+
+    let normalized = normalize_permission_request("claude", &message).unwrap();
+    assert_eq!(normalized.tool, "claude");
+    assert_eq!(normalized.id.as_deref(), Some("req-9"));
+    assert_eq!(normalized.session_id.as_deref(), Some("sess-9"));
+    assert_eq!(normalized.call_id.as_deref(), Some("tu-9"));
+    assert_eq!(normalized.tool_name.as_deref(), Some("Bash"));
+    assert_eq!(normalized.command.as_deref(), Some("npm test"));
+    assert_eq!(normalized.scope, "tool-input");
+    assert_eq!(normalized.input, Some(json!({ "command": "npm test" })));
+}
+
+#[test]
+fn normalize_claude_derives_command_from_file_path() {
+    let normalized = normalize_permission_request(
+        "claude",
+        &json!({
+            "type": "control_request",
+            "request_id": "req-10",
+            "request": {
+                "subtype": "can_use_tool",
+                "tool_name": "Edit",
+                "input": { "file_path": "/tmp/a.txt" },
+            },
+        }),
+    )
+    .unwrap();
+    assert_eq!(normalized.command.as_deref(), Some("/tmp/a.txt"));
+}
+
+#[test]
+fn normalize_claude_ignores_unrelated_control_request() {
+    assert!(normalize_permission_request(
+        "claude",
+        &json!({
+            "type": "control_request",
+            "request": { "subtype": "initialize" },
+        }),
+    )
+    .is_none());
+}
+
+fn agent_request(id: &str) -> NormalizedPermissionRequest {
+    normalize_permission_request(
+        "agent",
+        &json!({ "type": "permission_request", "permissionID": id, "tool": "bash" }),
+    )
+    .unwrap()
+}
+
+#[test]
+fn build_response_agent_maps_decisions_verbatim() {
+    let request = agent_request("perm-1");
+    for decision in ["once", "always", "reject"] {
+        let frame = build_permission_response("agent", &request, decision).unwrap();
+        assert_eq!(
+            frame,
+            json!({
+                "type": "permission_response",
+                "permissionID": "perm-1",
+                "response": decision,
+            })
+        );
+    }
+}
+
+fn claude_request(id: &str, command: &str) -> NormalizedPermissionRequest {
+    normalize_permission_request(
+        "claude",
+        &json!({
+            "type": "control_request",
+            "request_id": id,
+            "request": {
+                "subtype": "can_use_tool",
+                "tool_name": "Bash",
+                "input": { "command": command },
+            },
+        }),
+    )
+    .unwrap()
+}
+
+#[test]
+fn build_response_claude_reject_denies() {
+    let request = claude_request("req-1", "x");
+    let frame = build_permission_response("claude", &request, "reject").unwrap();
+    assert_eq!(frame["type"], "control_response");
+    assert_eq!(frame["response"]["subtype"], "success");
+    assert_eq!(frame["response"]["request_id"], "req-1");
+    assert_eq!(frame["response"]["response"]["behavior"], "deny");
+}
+
+#[test]
+fn build_response_claude_once_always_allow_with_input() {
+    let request = claude_request("req-2", "npm test");
+    for decision in ["once", "always"] {
+        let frame = build_permission_response("claude", &request, decision).unwrap();
+        assert_eq!(frame["response"]["response"]["behavior"], "allow");
+        assert_eq!(
+            frame["response"]["response"]["updatedInput"],
+            json!({ "command": "npm test" })
+        );
+    }
+}
+
+#[test]
+fn build_response_rejects_invalid_decision() {
+    let request = agent_request("x");
+    let err = build_permission_response("agent", &request, "maybe").unwrap_err();
+    assert!(err.contains("Invalid permission decision"));
+}
+
+#[test]
+fn build_response_rejects_unsupported_tool() {
+    let request = agent_request("x");
+    let err = build_permission_response("codex", &request, "once").unwrap_err();
+    assert!(err.contains("does not support enforceable per-command approval"));
+}
+
+#[test]
+fn permission_parity_covers_all_six_tools_with_scope_and_relay() {
+    let parity = permission_parity();
+    let mut tools: Vec<&str> = parity.iter().map(|row| row.tool).collect();
+    tools.sort_unstable();
+    assert_eq!(
+        tools,
+        vec!["agent", "claude", "codex", "gemini", "opencode", "qwen"]
+    );
+    for row in &parity {
+        assert!(!row.native_mechanism.is_empty());
+        assert!(!row.scope.is_empty());
+        assert!(!row.notes.is_empty());
+    }
+    let mut relayable: Vec<&str> = parity
+        .iter()
+        .filter(|row| row.relay)
+        .map(|row| row.tool)
+        .collect();
+    relayable.sort_unstable();
+    assert_eq!(relayable, vec!["agent", "claude"]);
+}
+
+#[test]
+fn relay_relays_an_agent_request_and_writes_the_response() {
+    let mut written: Vec<String> = Vec::new();
+    let decision;
+    {
+        let mut relay = PermissionRelay::new(
+            "agent",
+            |request: &NormalizedPermissionRequest| {
+                assert_eq!(request.id.as_deref(), Some("perm-1"));
+                assert_eq!(request.command.as_deref(), Some("rm -rf build"));
+                "always".to_string()
+            },
+            |line: &str| written.push(line.to_string()),
+        );
+
+        let (_, applied) = relay
+            .handle_message(&json!({
+                "type": "permission_request",
+                "permissionID": "perm-1",
+                "tool": "bash",
+                "metadata": { "command": "rm -rf build" },
+            }))
+            .unwrap();
+        decision = applied;
+        assert_eq!(relay.get_handled().len(), 1);
+    }
+
+    assert_eq!(decision, "always");
+    assert_eq!(written.len(), 1);
+    let frame: serde_json::Value = serde_json::from_str(&written[0]).unwrap();
+    assert_eq!(
+        frame,
+        json!({
+            "type": "permission_response",
+            "permissionID": "perm-1",
+            "response": "always",
+        })
+    );
+}
+
+#[test]
+fn relay_ignores_non_permission_messages() {
+    let mut written: Vec<String> = Vec::new();
+    {
+        let mut relay = PermissionRelay::new(
+            "agent",
+            |_: &NormalizedPermissionRequest| "once".to_string(),
+            |line: &str| written.push(line.to_string()),
+        );
+        let result = relay.handle_message(&json!({ "type": "step_finish" }));
+        assert!(result.is_none());
+    }
+    assert_eq!(written.len(), 0);
+}
+
+#[test]
+fn relay_defaults_invalid_consumer_decision_to_reject() {
+    let mut written: Vec<String> = Vec::new();
+    let decision;
+    {
+        let mut relay = PermissionRelay::new(
+            "claude",
+            |_: &NormalizedPermissionRequest| "banana".to_string(),
+            |line: &str| written.push(line.to_string()),
+        );
+        let (_, applied) = relay
+            .handle_message(&json!({
+                "type": "control_request",
+                "request_id": "req-1",
+                "request": { "subtype": "can_use_tool", "tool_name": "Bash", "input": { "command": "x" } },
+            }))
+            .unwrap();
+        decision = applied;
+    }
+    assert_eq!(decision, "reject");
+    let frame: serde_json::Value = serde_json::from_str(&written[0]).unwrap();
+    assert_eq!(frame["response"]["response"]["behavior"], "deny");
+}
+
+#[test]
+fn relay_claude_allow_forwards_updated_input() {
+    let mut written: Vec<String> = Vec::new();
+    {
+        let mut relay = PermissionRelay::new(
+            "claude",
+            |_: &NormalizedPermissionRequest| "once".to_string(),
+            |line: &str| written.push(line.to_string()),
+        );
+        relay
+            .handle_message(&json!({
+                "type": "control_request",
+                "request_id": "req-2",
+                "request": {
+                    "subtype": "can_use_tool",
+                    "tool_name": "Bash",
+                    "input": { "command": "npm test" },
+                },
+            }))
+            .unwrap();
+    }
+    let frame: serde_json::Value = serde_json::from_str(&written[0]).unwrap();
+    assert_eq!(frame["response"]["response"]["behavior"], "allow");
+    assert_eq!(
+        frame["response"]["response"]["updatedInput"],
+        json!({ "command": "npm test" })
+    );
+}


### PR DESCRIPTION
## Summary

Implements a **uniform per-command approval ("ask" mode)** relay, closing #40.

A single option — `--approve-each` (alias `--permission-mode ask`, library `approveEach` / `approve_each`) — maps to each backend's native per-command approval mechanism. For backends that expose a drivable JSON handshake, every native permission prompt is **relayed to the consumer** as a normalized NDJSON `permission_request` event and the consumer's normalized decision (`once` | `always` | `reject`) is **forwarded back** to the native CLI in its own wire format. Backends with no relayable handshake fail clearly up front — the same pattern `--read-only` uses (precedent: #41 / #39).

Fixes #40

## What each part of the issue maps to

1. **Uniform option →** `--approve-each` / `--permission-mode ask`, threaded through CLI parser → command builder → controller in both JS and Rust.
2. **Relay + scope →** a normalized request carries `{ type, tool, id, sessionId, callId, toolName, title, command, pattern, scope, input }`. The decision is translated to the native frame: agent's `permission_response`, Claude's `control_response` (`allow`/`deny`, echoing `updatedInput`).
3. **Parity table with a scope column →** documented in `docs/common-concepts.md` (addresses @m13v's note that `always` differs per backend: agent = `session`, claude = `tool-input`).

## Parity (scope column included)

| Tool | Native mechanism | Scope | Relay |
| --- | --- | --- | --- |
| `agent` | `--permission-mode ask` (+ `--input-format stream-json`) | `session` | ✅ |
| `claude` | `--permission-mode default` (stream-json `can_use_tool`) | `tool-input` | ✅ |
| `codex` | `--ask-for-approval` (coupled with `--sandbox`) | `sandbox-coupled` | ❌ |
| `qwen` | `--approval-mode default` | `interactive-only` | ❌ |
| `gemini` | `--approval-mode default` | `interactive-only` | ❌ |
| `opencode` | `OPENCODE_PERMISSION` (static policy) | `static-policy` | ❌ |

Only `agent` and `claude` can drive the handshake. For the others, `--approve-each` is rejected with: `Tool "<tool>" does not support enforceable per-command approval (ask mode). Choose one of: agent, claude; or run without --approve-each.`

## How to reproduce / try it

A runnable, dependency-free demo of the relay (no agent process required):

```bash
node examples/permission-relay.mjs
```

It feeds native `permission_request` / `can_use_tool` frames into a `PermissionRelay` and prints the exact native response frames forwarded to the CLI's stdin (e.g. agent `permission_response`, Claude `control_response` allow/deny). It also shows that unsupported tools and non-permission messages are handled correctly.

End-to-end, a consumer runs:

```bash
start-agent --tool agent --working-directory /tmp/project --prompt "..." --approve-each
```

`start-agent` emits one normalized `permission_request` NDJSON line per command to stdout and reads `{"type":"permission_response","id":"...","decision":"once|always|reject"}` from stdin.

## Tests

- **JS:** new `js/test/permissions.test.mjs` (21 tests) plus additions to cli-parser, command-builder, index, and tools suites — **230 passing**, lint + format clean.
- **Rust:** new `rust/tests/permissions_tests.rs` (20 tests) plus inline tests in `command_builder.rs` and `cli_parser.rs` — full suite green, `cargo fmt --check`, `cargo clippy --all-targets --all-features` (with `-Dwarnings`) clean.

## Release

- JS changeset (`minor`) and Rust changelog fragment (`minor`); versions are bumped automatically by the release workflows on merge.
